### PR TITLE
Add OSC 8 hyperlink support for clickable file paths and URLs

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		459FB063C7F788F4E0E549A5 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89FDA87579791818D3A6718 /* TerminalPane.swift */; };
 		4859630C40EA72D0F6A13448 /* SSHLaunchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A6320778E024E8ABCDF2A6 /* SSHLaunchBuilder.swift */; };
 		4C6D7ECB973811FC8DA4121C /* ProcessMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A46EAB948FDDFB1C12E4B9 /* ProcessMonitor.swift */; };
+		4DDD96881F2A1409729CD580 /* HyperlinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2088BFA03DDDC079DE5DB8C /* HyperlinkRouter.swift */; };
+		5863C9295DF764ABD02BC958 /* HyperlinkRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC1927EB617093208667D9 /* HyperlinkRouterTests.swift */; };
 		5DD63722AB2EE526EB096050 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E2025F109793353C35658F9 /* GhosttyKit.xcframework */; };
 		6798D6E2D3D556D644A18E41 /* SSHProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879EFDEE63113B30DD38B6EA /* SSHProfileStore.swift */; };
 		6D65D2902B34E20D77196A44 /* TerminalSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41878447E775AEA363F6EF96 /* TerminalSurfaceView.swift */; };
@@ -106,6 +108,7 @@
 		7AF3EFCA4440E50031AF178C /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		7B6A4E8E8C5D7B65BB385570 /* ContextBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextBadgeView.swift; sourceTree = "<group>"; };
 		7B73776D795BE3450D431B7B /* NetworkPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPanel.swift; sourceTree = "<group>"; };
+		7CDC1927EB617093208667D9 /* HyperlinkRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperlinkRouterTests.swift; sourceTree = "<group>"; };
 		84F589203C90A72C2C4DA09C /* SSHPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPane.swift; sourceTree = "<group>"; };
 		879EFDEE63113B30DD38B6EA /* SSHProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHProfileStore.swift; sourceTree = "<group>"; };
 		8932FC29FCA31DEBC5C25A11 /* ProcessMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMonitorTests.swift; sourceTree = "<group>"; };
@@ -139,6 +142,7 @@
 		EA87F2112E9FD1A9C106D8F2 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		EC69484808B270DA784451B1 /* SearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarView.swift; sourceTree = "<group>"; };
 		F00EF9188ECCF6928DD41F54 /* StatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarView.swift; sourceTree = "<group>"; };
+		F2088BFA03DDDC079DE5DB8C /* HyperlinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperlinkRouter.swift; sourceTree = "<group>"; };
 		FC5966D19E6F059737E8B875 /* TerminalContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalContext.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -181,6 +185,7 @@
 			isa = PBXGroup;
 			children = (
 				A97FAFCF93CCB562713620EE /* BellithFont.swift */,
+				F2088BFA03DDDC079DE5DB8C /* HyperlinkRouter.swift */,
 				7AF3EFCA4440E50031AF178C /* Logger.swift */,
 			);
 			path = Utilities;
@@ -190,6 +195,7 @@
 			isa = PBXGroup;
 			children = (
 				4FD22E965C6F1A921DC3AFFA /* BellithSettingsTests.swift */,
+				7CDC1927EB617093208667D9 /* HyperlinkRouterTests.swift */,
 				9CB945FE301FBB1B34329681 /* KeyShortcutTests.swift */,
 				8932FC29FCA31DEBC5C25A11 /* ProcessMonitorTests.swift */,
 				1B08540536C434953689D04D /* SessionStateTests.swift */,
@@ -427,6 +433,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				84920B35B7A5167C2AAE9985 /* BellithSettingsTests.swift in Sources */,
+				5863C9295DF764ABD02BC958 /* HyperlinkRouterTests.swift in Sources */,
 				1FE6195879EE4D4D65B24CC1 /* KeyShortcutTests.swift in Sources */,
 				B80E5D2747AB50B714189BC4 /* ProcessMonitorTests.swift in Sources */,
 				196EB5C6360D08B30D2E9D84 /* SSHLaunchBuilderTests.swift in Sources */,
@@ -453,6 +460,7 @@
 				18245BFE622B231108C45FFC /* ContextBadgeView.swift in Sources */,
 				3F81E95CDC0FF4142056C98A /* EnvironmentPanel.swift in Sources */,
 				FA077AEA422D8D9128490402 /* FileActivityPanel.swift in Sources */,
+				4DDD96881F2A1409729CD580 /* HyperlinkRouter.swift in Sources */,
 				A58FC4DBB6D1A65B63DEEC49 /* InputHelpers.swift in Sources */,
 				FE9D5CEE859363C51ADCC2CF /* KeyBindings.swift in Sources */,
 				A39350253246932A3A4CB068 /* KeybindingsPane.swift in Sources */,

--- a/Bellith/App/AppDelegate.swift
+++ b/Bellith/App/AppDelegate.swift
@@ -593,9 +593,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         case GHOSTTY_ACTION_OPEN_URL:
             if let urlPtr = action.action.open_url.url {
                 let str = String(cString: urlPtr)
-                if let url = URL(string: str) {
-                    NSWorkspace.shared.open(url)
-                }
+                _ = HyperlinkRouter.open(str)
             }
             return true
 

--- a/Bellith/Bridge/TerminalConfig.swift
+++ b/Bellith/Bridge/TerminalConfig.swift
@@ -54,6 +54,7 @@ final class TerminalConfig {
             "window-decoration = false",
             "window-save-state = never",
             "mouse-hide-while-typing = \(s.mouseHideWhileTyping)",
+            "link-url = true",
             "confirm-close-surface = \(s.confirmClose)",
             "keybind = clear",
         ]

--- a/Bellith/Utilities/HyperlinkRouter.swift
+++ b/Bellith/Utilities/HyperlinkRouter.swift
@@ -1,0 +1,24 @@
+import AppKit
+import Foundation
+
+enum HyperlinkRouter {
+    static func open(
+        _ rawValue: String,
+        using opener: (URL) -> Bool = { NSWorkspace.shared.open($0) }
+    ) -> Bool {
+        guard let url = resolve(rawValue) else { return false }
+        return opener(url)
+    }
+
+    static func resolve(_ rawValue: String) -> URL? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let url = URL(string: trimmed), let scheme = url.scheme, !scheme.isEmpty {
+            return url.isFileURL ? url.standardizedFileURL : url
+        }
+
+        guard trimmed.hasPrefix("/") else { return nil }
+        return URL(fileURLWithPath: trimmed).standardizedFileURL
+    }
+}

--- a/Bellith/Views/TerminalSurfaceView.swift
+++ b/Bellith/Views/TerminalSurfaceView.swift
@@ -383,6 +383,10 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
         key_ev.composing = false
         key_ev.unshifted_codepoint = 0
         ghostty_surface_key(surface, key_ev)
+
+        // Hyperlink activation on macOS is modifier-sensitive, so hovering a
+        // stationary pointer while pressing Command still needs a fresh update.
+        sendMousePos(event)
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
@@ -458,26 +462,40 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
     override func mouseDown(with event: NSEvent) {
         guard let surface else { return }
         window?.makeFirstResponder(self)
+        sendMousePos(event)
         ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT,
                                      InputHelpers.ghosttyMods(event.modifierFlags))
     }
 
     override func mouseUp(with event: NSEvent) {
         guard let surface else { return }
+        sendMousePos(event)
         ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT,
                                      InputHelpers.ghosttyMods(event.modifierFlags))
     }
 
     override func rightMouseDown(with event: NSEvent) {
         guard let surface else { return }
+        sendMousePos(event)
         ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT,
                                      InputHelpers.ghosttyMods(event.modifierFlags))
     }
 
     override func rightMouseUp(with event: NSEvent) {
         guard let surface else { return }
+        sendMousePos(event)
         ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT,
                                      InputHelpers.ghosttyMods(event.modifierFlags))
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        sendMousePos(event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        sendMousePos(event)
     }
 
     override func mouseMoved(with event: NSEvent) { sendMousePos(event) }

--- a/BellithTests/HyperlinkRouterTests.swift
+++ b/BellithTests/HyperlinkRouterTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+@testable import Bellith
+
+final class HyperlinkRouterTests: XCTestCase {
+    func testResolveTrimsAndPreservesHTTPSURLs() {
+        let url = HyperlinkRouter.resolve("  https://example.com/path?q=1  ")
+
+        XCTAssertEqual(url?.absoluteString, "https://example.com/path?q=1")
+    }
+
+    func testResolveStandardizesFileURLs() {
+        let url = HyperlinkRouter.resolve("file:///tmp/../tmp/example.swift")
+
+        XCTAssertEqual(url?.path, "/tmp/example.swift")
+        XCTAssertTrue(url?.isFileURL ?? false)
+    }
+
+    func testResolvePromotesAbsolutePathsToFileURLs() {
+        let url = HyperlinkRouter.resolve("/tmp/example.swift")
+
+        XCTAssertEqual(url?.path, "/tmp/example.swift")
+        XCTAssertTrue(url?.isFileURL ?? false)
+    }
+
+    func testResolveRejectsPlainTextWithoutSchemeOrPath() {
+        XCTAssertNil(HyperlinkRouter.resolve("not a url"))
+    }
+
+    func testOpenUsesInjectedOpener() {
+        var openedURL: URL?
+
+        let didOpen = HyperlinkRouter.open("https://bellith.dev") { url in
+            openedURL = url
+            return true
+        }
+
+        XCTAssertTrue(didOpen)
+        XCTAssertEqual(openedURL?.absoluteString, "https://bellith.dev")
+    }
+}

--- a/BellithTests/TerminalConfigTests.swift
+++ b/BellithTests/TerminalConfigTests.swift
@@ -20,6 +20,7 @@ final class TerminalConfigTests: XCTestCase {
         XCTAssertTrue(contents.contains("background-opacity"), "Config should contain background-opacity")
         XCTAssertTrue(contents.contains("cursor-style"), "Config should contain cursor-style")
         XCTAssertTrue(contents.contains("scrollback-limit"), "Config should contain scrollback-limit")
+        XCTAssertTrue(contents.contains("link-url = true"), "Config should enable clickable links")
         XCTAssertTrue(contents.contains("keybind = clear"), "Config should clear keybinds")
     }
 


### PR DESCRIPTION
## Summary
- refresh Ghostty mouse state on enter/exit, click, and modifier-only changes so hyperlink hover and Cmd-click activation stay in sync
- make Bellith's generated Ghostty config explicitly enable clickable links and route opened links through a shared resolver that handles both web URLs and local file targets
- add regression tests for hyperlink resolution plus the generated config, and regenerate the Xcode project so the new sources are included

## Testing
- xcodebuild -project Bellith.xcodeproj -scheme Bellith -configuration Debug -derivedDataPath /tmp/bellith-deriveddata test

Closes #1