### PR TITLE
feat(terminal): add TERM override and capability docs

### DIFF
--- a/Bellith/Bridge/TerminalConfig.swift
+++ b/Bellith/Bridge/TerminalConfig.swift
@@ -43,6 +43,7 @@ final class TerminalConfig {
             "font-family = \(s.fontFamily)",
             "font-size = \(s.fontSize)",
             "theme = \(s.resolvedTheme.ghosttyTheme)",
+            "term = \(s.effectiveTerminalTerm)",
             "background-opacity = \(s.backgroundOpacity)",
             "window-padding-x = \(s.windowPaddingX)",
             "window-padding-y = \(s.windowPaddingY),2",

--- a/Bellith/Models/BellithSettings.swift
+++ b/Bellith/Models/BellithSettings.swift
@@ -5,6 +5,7 @@ import AppKit
 final class BellithSettings {
     static let shared = BellithSettings()
     static let didChangeNotification = Notification.Name("BellithSettingsDidChange")
+    static let defaultTerminalTerm = "xterm-ghostty"
 
     let defaults: UserDefaults
 
@@ -57,6 +58,14 @@ final class BellithSettings {
     var shell: String {
         get { defaults.string(forKey: "shell") ?? "" } // empty = login shell
         set { defaults.set(newValue, forKey: "shell"); notify() }
+    }
+
+    var terminalTerm: String {
+        get { defaults.string(forKey: "terminalTerm") ?? "" } // empty = Ghostty default TERM
+        set {
+            defaults.set(newValue.trimmingCharacters(in: .whitespacesAndNewlines), forKey: "terminalTerm")
+            notify()
+        }
     }
 
     var scrollbackLines: Int {
@@ -401,5 +410,10 @@ final class BellithSettings {
         ]
         .map { $0.0 ? $0.1 : "no-\($0.1)" }
         .joined(separator: ",")
+    }
+
+    var effectiveTerminalTerm: String {
+        let trimmed = terminalTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? Self.defaultTerminalTerm : trimmed
     }
 }

--- a/Bellith/Views/Preferences/TerminalPane.swift
+++ b/Bellith/Views/Preferences/TerminalPane.swift
@@ -33,10 +33,13 @@ final class TerminalPane: NSView {
     private let cursorColorLabel = CardRowLabel("Cursor Color")
     private let cursorColorNote = FooterNote("Inherited from the selected theme")
 
-    private let sessionCard = SettingsCard(title: "Session Defaults", subtitle: "Shell, directory, scrollback, and bell behavior")
+    private let sessionCard = SettingsCard(title: "Session Defaults", subtitle: "Shell, TERM, directory, scrollback, and bell behavior")
     private let shellLabel = CardRowLabel("Shell Command")
     private var shellField: PrefTextField!
     private let shellNote = FooterNote("Leave empty to use the login shell")
+    private let termLabel = CardRowLabel("TERM")
+    private var termField: PrefTextField!
+    private let termNote = FooterNote("Leave empty to use xterm-ghostty")
     private let cwdLabel = CardRowLabel("Start Directory")
     private var cwdField: PrefTextField!
     private let cwdNote = FooterNote("Used for new tabs and restored sessions")
@@ -149,6 +152,9 @@ final class TerminalPane: NSView {
             self?.settings.shell = value
             self?.updateHero()
         }
+        termField = PrefTextField(text: settings.terminalTerm) { [weak self] value in
+            self?.settings.terminalTerm = value
+        }
         cwdField = PrefTextField(text: settings.workingDirectory) { [weak self] value in
             self?.settings.workingDirectory = value
             self?.updateHero()
@@ -162,7 +168,22 @@ final class TerminalPane: NSView {
             self?.updateHero()
         }
         content.addSubview(sessionCard)
-        for view: NSView in [shellLabel, shellField, shellNote, cwdLabel, cwdField, cwdNote, scrollLabel, scrollField, scrollUnit, bellLabel, bellSegment] {
+        for view: NSView in [
+            shellLabel,
+            shellField,
+            shellNote,
+            termLabel,
+            termField,
+            termNote,
+            cwdLabel,
+            cwdField,
+            cwdNote,
+            scrollLabel,
+            scrollField,
+            scrollUnit,
+            bellLabel,
+            bellSegment
+        ] {
             sessionCard.addSubview(view)
         }
 
@@ -229,6 +250,7 @@ final class TerminalPane: NSView {
         cursorSegment.setSelected(["block": 0, "bar": 1, "underline": 2][settings.cursorStyle] ?? 0)
         blinkToggle.setOn(settings.cursorBlink)
         shellField.updateText(settings.shell)
+        termField.updateText(settings.terminalTerm)
         cwdField.updateText(settings.workingDirectory)
         scrollField.setValue(settings.scrollbackLines)
         bellSegment.setSelected(["system": 0, "visual": 1, "bounce": 2, "none": 3][settings.bellMode] ?? 0)
@@ -317,7 +339,7 @@ final class TerminalPane: NSView {
         cursorColorNote.frame = NSRect(x: controlX, y: cr2 + 12, width: controlW, height: 14)
         y += cursorCardHeight + PreferencesLayout.sectionGap
 
-        let sessionCardHeight = sessionCard.headerHeight + 4 * PreferencesLayout.rowH + 2 * 14 + 3 * PreferencesLayout.rowGap + PreferencesLayout.cardPad
+        let sessionCardHeight = sessionCard.headerHeight + 5 * PreferencesLayout.rowH + 3 * 14 + 4 * PreferencesLayout.rowGap + PreferencesLayout.cardPad
         sessionCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardW, height: sessionCardHeight)
         let sr0 = sessionCardHeight - sessionCard.headerHeight - PreferencesLayout.rowH
         shellLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: sr0, width: labelW - 12, height: PreferencesLayout.rowH)
@@ -325,17 +347,22 @@ final class TerminalPane: NSView {
         let shellNoteY = sr0 - 14
         shellNote.frame = NSRect(x: controlX, y: shellNoteY, width: controlW, height: 14)
         let sr1 = shellNoteY - PreferencesLayout.rowH
-        cwdLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: sr1, width: labelW - 12, height: PreferencesLayout.rowH)
-        cwdField.frame = NSRect(x: controlX, y: sr1 + 6, width: controlW, height: 28)
-        let cwdNoteY = sr1 - 14
+        termLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: sr1, width: labelW - 12, height: PreferencesLayout.rowH)
+        termField.frame = NSRect(x: controlX, y: sr1 + 6, width: controlW, height: 28)
+        let termNoteY = sr1 - 14
+        termNote.frame = NSRect(x: controlX, y: termNoteY, width: controlW, height: 14)
+        let sr2 = termNoteY - PreferencesLayout.rowH
+        cwdLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: sr2, width: labelW - 12, height: PreferencesLayout.rowH)
+        cwdField.frame = NSRect(x: controlX, y: sr2 + 6, width: controlW, height: 28)
+        let cwdNoteY = sr2 - 14
         cwdNote.frame = NSRect(x: controlX, y: cwdNoteY, width: controlW, height: 14)
-        let sr2 = cwdNoteY - PreferencesLayout.rowH
-        scrollLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: sr2, width: labelW - 12, height: PreferencesLayout.rowH)
-        scrollField.frame = NSRect(x: controlX, y: sr2 + 6, width: 96, height: 28)
-        scrollUnit.frame = NSRect(x: controlX + 106, y: sr2 + 12, width: 40, height: 12)
-        let sr3 = sr2 - PreferencesLayout.rowH - PreferencesLayout.rowGap
-        bellLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: sr3, width: labelW - 12, height: PreferencesLayout.rowH)
-        bellSegment.frame = NSRect(x: controlX, y: sr3 + 6, width: min(320, controlW), height: 28)
+        let sr3 = cwdNoteY - PreferencesLayout.rowH
+        scrollLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: sr3, width: labelW - 12, height: PreferencesLayout.rowH)
+        scrollField.frame = NSRect(x: controlX, y: sr3 + 6, width: 96, height: 28)
+        scrollUnit.frame = NSRect(x: controlX + 106, y: sr3 + 12, width: 40, height: 12)
+        let sr4 = sr3 - PreferencesLayout.rowH - PreferencesLayout.rowGap
+        bellLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: sr4, width: labelW - 12, height: PreferencesLayout.rowH)
+        bellSegment.frame = NSRect(x: controlX, y: sr4 + 6, width: min(320, controlW), height: 28)
         y += sessionCardHeight + PreferencesLayout.sectionGap
 
         let shellToggleX = cardW - PreferencesLayout.cardPad - 50

--- a/BellithTests/BellithSettingsTests.swift
+++ b/BellithTests/BellithSettingsTests.swift
@@ -51,6 +51,11 @@ final class BellithSettingsTests: XCTestCase {
         XCTAssertEqual(settings.shell, "")
     }
 
+    func testDefaultTerminalTermUsesGhosttyTerminfo() {
+        XCTAssertEqual(settings.terminalTerm, "")
+        XCTAssertEqual(settings.effectiveTerminalTerm, BellithSettings.defaultTerminalTerm)
+    }
+
     func testDefaultScrollbackLines() {
         XCTAssertEqual(settings.scrollbackLines, 10000)
     }
@@ -145,6 +150,13 @@ final class BellithSettingsTests: XCTestCase {
             settings.shellIntegrationFeatures,
             "no-cursor,no-title,no-path,no-ssh-env,ssh-terminfo"
         )
+    }
+
+    func testTerminalTermRoundtripAndTrimming() {
+        settings.terminalTerm = "  xterm-256color  "
+
+        XCTAssertEqual(settings.terminalTerm, "xterm-256color")
+        XCTAssertEqual(settings.effectiveTerminalTerm, "xterm-256color")
     }
 
     // MARK: - Keybindings

--- a/BellithTests/TerminalConfigTests.swift
+++ b/BellithTests/TerminalConfigTests.swift
@@ -35,6 +35,7 @@ final class TerminalConfigTests: XCTestCase {
         XCTAssertTrue(contents.contains("font-family"), "Config should contain font-family")
         XCTAssertTrue(contents.contains("font-size"), "Config should contain font-size")
         XCTAssertTrue(contents.contains("theme"), "Config should contain theme")
+        XCTAssertTrue(contents.contains("term = xterm-ghostty"), "Config should set Ghostty's default TERM explicitly")
         XCTAssertTrue(contents.contains("background-opacity"), "Config should contain background-opacity")
         XCTAssertTrue(contents.contains("cursor-style"), "Config should contain cursor-style")
         XCTAssertTrue(contents.contains("scrollback-limit"), "Config should contain scrollback-limit")
@@ -47,6 +48,7 @@ final class TerminalConfigTests: XCTestCase {
     func testWrittenFileReflectsCurrentSettings() throws {
         settings.fontFamily = "JetBrains Mono"
         settings.fontSize = 18
+        settings.terminalTerm = "xterm-256color"
         settings.shellIntegrationCursor = false
         settings.shellIntegrationSSHTerminfo = true
 
@@ -60,6 +62,8 @@ final class TerminalConfigTests: XCTestCase {
                        "Config should reflect current font family")
         XCTAssertTrue(contents.contains("font-size = \(settings.fontSize)"),
                        "Config should reflect current font size")
+        XCTAssertTrue(contents.contains("term = xterm-256color"),
+                      "Config should reflect the TERM override")
         XCTAssertTrue(
             contents.contains("shell-integration-features = no-cursor,title,path,ssh-env,ssh-terminfo"),
             "Config should reflect shell integration feature toggles"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A native macOS terminal emulator built with Swift and [Ghostty](https://ghostty.
 - **Command palette** — Quick access to actions via `⌘K`
 - **Themes** — Built-in themes including Tokyo Night, Catppuccin Mocha, Gruvbox Dark, Rosé Pine, Nord, and Solarized Dark
 - **Preferences** — Configurable settings with persistent storage
+- **TERM-aware defaults** — Explicit `xterm-ghostty` advertising with an override for legacy tooling
 - **Frameless window** — Clean, minimal window chrome with custom title bar
 
 ## Requirements
@@ -66,6 +67,20 @@ make generate # Regenerate Xcode project from project.yml
 | `⌘⇧E` | Toggle sidebar |
 | `⌘K` | Command palette |
 | `⌘,` | Preferences |
+
+## Terminal Capabilities
+
+Bellith writes Ghostty's `term` setting explicitly and defaults to `xterm-ghostty`. That gives local shells the full Ghostty terminfo entry instead of relying on an implicit runtime default. If a workflow requires a more conservative value such as `xterm-256color`, use `Settings > Terminal > TERM`.
+
+Bellith inherits Ghostty's 24-bit color support. A quick manual check is:
+
+```bash
+printf '\033[38;2;255;95;31mTRUECOLOR\033[0m\n'
+```
+
+If the sample renders in a bright orange-red instead of a palette approximation, direct RGB color sequences are working.
+
+For SSH sessions, Bellith already enables Ghostty's `ssh-env` compatibility by default. That makes remote connections fall back to `xterm-256color` while propagating compatibility variables. If you also enable `SSH Terminfo Install` in Terminal settings, Ghostty will attempt to install `xterm-ghostty` terminfo remotely so compatible hosts can keep the richer TERM value.
 
 ## UI Anatomy
 


### PR DESCRIPTION
## Summary
- write Ghostty's TERM explicitly and add a Terminal preferences override
- add TERM regression coverage for settings and generated Ghostty config
- document TERM, truecolor, and SSH terminfo behavior for users

## Testing
- xcodebuild -project Bellith.xcodeproj -scheme Bellith -configuration Debug -derivedDataPath /tmp/bellith-derived build
- xcodebuild -project Bellith.xcodeproj -scheme Bellith -configuration Debug -derivedDataPath /tmp/bellith-derived test -only-testing:BellithTests/BellithSettingsTests -only-testing:BellithTests/TerminalConfigTests

Closes #3