### PR TITLE
fix(app): surface critical startup errors

### DIFF
--- a/Bellith/App/AppDelegate.swift
+++ b/Bellith/App/AppDelegate.swift
@@ -19,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var windows: [WindowEntry] = []
     private var newWindowObserver: NSObjectProtocol?
     private var appearanceObserver: NSObjectProtocol?
+    private var terminalConfigFailureObserver: NSObjectProtocol?
     private var themeMenu = NSMenu(title: "Theme")
 
     private struct WindowEntry {
@@ -38,22 +39,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let argc: UInt = 0
         let initResult = ghostty_init(argc, nil)
         guard initResult == GHOSTTY_SUCCESS else {
-            Logger.app.error("Failed to initialize ghostty: \(String(describing: initResult))")
-            NSApp.terminate(nil)
+            presentStartupFailure(
+                title: "Bellith Could Not Start",
+                message: "Ghostty failed to initialize.",
+                informativeText: "Bellith could not start its terminal runtime."
+            )
             return
+        }
+
+        terminalConfigFailureObserver = NotificationCenter.default.addObserver(
+            forName: .terminalConfigDidFail, object: nil, queue: .main
+        ) { [weak self] notification in
+            guard let error = notification.object as? TerminalConfigError else { return }
+            self?.presentTerminalConfigError(error)
         }
 
         let config = TerminalConfig()
         guard config.config != nil else {
-            Logger.app.error("Failed to create ghostty config")
             NSApp.terminate(nil)
             return
         }
 
         let app = TerminalApp(config: config)
         guard app.app != nil else {
-            Logger.app.error("Failed to create ghostty app")
-            NSApp.terminate(nil)
+            presentStartupFailure(
+                title: "Bellith Could Not Start",
+                message: "Ghostty failed to create the terminal app.",
+                informativeText: "Bellith could not create its terminal runtime."
+            )
             return
         }
         self.terminalApp = app
@@ -130,6 +143,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         if let obs = newWindowObserver {
             NotificationCenter.default.removeObserver(obs)
             newWindowObserver = nil
+        }
+        if let obs = terminalConfigFailureObserver {
+            NotificationCenter.default.removeObserver(obs)
+            terminalConfigFailureObserver = nil
         }
 
         // Tear down all windows
@@ -279,9 +296,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
         // Edit menu
         let editMenu = NSMenu(title: "Edit")
-        editMenu.addItem(withTitle: "Undo", action: #selector(UndoManager.undo), keyEquivalent: "z")
-        editMenu.addItem(withTitle: "Redo", action: #selector(UndoManager.redo), keyEquivalent: "z").keyEquivalentModifierMask = [.command, .shift]
-        editMenu.addItem(.separator())
         editMenu.addItem(withTitle: "Copy", action: #selector(handleCopy), keyEquivalent: "c")
         editMenu.addItem(withTitle: "Paste", action: #selector(handlePaste), keyEquivalent: "v")
         editMenu.addItem(withTitle: "Select All", action: #selector(handleSelectAll), keyEquivalent: "a")
@@ -499,6 +513,44 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             let appearance = theme.isLight ? NSAppearance(named: .aqua) : NSAppearance(named: .darkAqua)
             if let self {
                 for entry in self.windows { entry.window.appearance = appearance }
+            }
+        }
+    }
+
+    private func presentTerminalConfigError(_ error: TerminalConfigError) {
+        presentAlert(
+            title: "Bellith Configuration Error",
+            message: error.errorDescription ?? "Bellith could not load its configuration.",
+            informativeText: error.failureReason
+        )
+    }
+
+    private func presentStartupFailure(title: String, message: String, informativeText: String) {
+        presentAlert(title: title, message: message, informativeText: informativeText, terminateAfterDismissal: true)
+    }
+
+    private func presentAlert(
+        title: String,
+        message: String,
+        informativeText: String? = nil,
+        terminateAfterDismissal: Bool = false
+    ) {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = title
+        alert.informativeText = [message, informativeText].compactMap { $0 }.joined(separator: "\n\n")
+
+        NSApp.activate(ignoringOtherApps: true)
+        if let window = activeEntry?.window ?? NSApp.keyWindow {
+            alert.beginSheetModal(for: window) { _ in
+                if terminateAfterDismissal {
+                    NSApp.terminate(nil)
+                }
+            }
+        } else {
+            _ = alert.runModal()
+            if terminateAfterDismissal {
+                NSApp.terminate(nil)
             }
         }
     }

--- a/Bellith/Bridge/TerminalConfig.swift
+++ b/Bellith/Bridge/TerminalConfig.swift
@@ -3,16 +3,57 @@ import GhosttyKit
 
 // MARK: - Ghostty Config Wrapper
 
+enum TerminalConfigError: LocalizedError {
+    case failedToCreateGhosttyConfig
+    case applicationSupportDirectoryUnavailable
+    case failedToCreateConfigDirectory(URL, underlying: Error)
+    case failedToWriteConfigFile(URL, underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .failedToCreateGhosttyConfig:
+            return "Bellith could not initialize Ghostty's configuration."
+        case .applicationSupportDirectoryUnavailable:
+            return "Bellith could not locate the Application Support directory."
+        case .failedToCreateConfigDirectory(let url, _):
+            return "Bellith could not create its configuration directory at \(url.path)."
+        case .failedToWriteConfigFile(let url, _):
+            return "Bellith could not write its configuration file at \(url.path)."
+        }
+    }
+
+    var failureReason: String? {
+        switch self {
+        case .failedToCreateGhosttyConfig, .applicationSupportDirectoryUnavailable:
+            return nil
+        case .failedToCreateConfigDirectory(_, let underlying), .failedToWriteConfigFile(_, let underlying):
+            return underlying.localizedDescription
+        }
+    }
+}
+
+extension Notification.Name {
+    static let terminalConfigDidFail = Notification.Name("TerminalConfigDidFail")
+}
+
 final class TerminalConfig {
     private(set) var config: ghostty_config_t?
+    private(set) var configurationError: TerminalConfigError?
 
-    init() {
+    init(configurationDirectory: URL? = nil) {
         config = ghostty_config_new()
-        guard config != nil else { return }
+        guard config != nil else {
+            report(.failedToCreateGhosttyConfig)
+            return
+        }
 
-        let configPath = Self.writeConfigFile()
-        if let path = configPath {
+        do {
+            let path = try Self.writeConfigFile(configurationDirectory: configurationDirectory)
             path.withCString { ghostty_config_load_file(config, $0) }
+        } catch let error as TerminalConfigError {
+            report(error)
+        } catch {
+            report(.applicationSupportDirectoryUnavailable)
         }
 
         ghostty_config_finalize(config)
@@ -32,10 +73,20 @@ final class TerminalConfig {
         }
     }
 
-    static func writeConfigFile(settings: BellithSettings = .shared) -> String? {
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("com.rec.bellith", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    static func writeConfigFile(
+        settings: BellithSettings = .shared,
+        configurationDirectory: URL? = nil
+    ) throws -> String {
+        let defaultDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        guard let dir = configurationDirectory ?? defaultDirectory?.appendingPathComponent("com.rec.bellith", isDirectory: true) else {
+            throw TerminalConfigError.applicationSupportDirectoryUnavailable
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            throw TerminalConfigError.failedToCreateConfigDirectory(dir, underlying: error)
+        }
 
         let s = settings
         let file = dir.appendingPathComponent("config.conf")
@@ -46,7 +97,7 @@ final class TerminalConfig {
             "term = \(s.effectiveTerminalTerm)",
             "background-opacity = \(s.backgroundOpacity)",
             "window-padding-x = \(s.windowPaddingX)",
-            "window-padding-y = \(s.windowPaddingY),2",
+            "window-padding-y = \(s.windowPaddingY)",
             "window-padding-balance = false",
             "cursor-style = \(s.cursorStyle)",
             "cursor-style-blink = \(s.cursorBlink)",
@@ -68,7 +119,12 @@ final class TerminalConfig {
             try lines.joined(separator: "\n").write(to: file, atomically: true, encoding: .utf8)
             return file.path
         } catch {
-            return nil
+            throw TerminalConfigError.failedToWriteConfigFile(file, underlying: error)
         }
+    }
+
+    private func report(_ error: TerminalConfigError) {
+        configurationError = error
+        NotificationCenter.default.post(name: .terminalConfigDidFail, object: error)
     }
 }

--- a/BellithTests/TerminalConfigTests.swift
+++ b/BellithTests/TerminalConfigTests.swift
@@ -21,15 +21,12 @@ final class TerminalConfigTests: XCTestCase {
     }
 
     func testWriteConfigFileReturnsPath() {
-        let path = TerminalConfig.writeConfigFile(settings: settings)
+        let path = try? TerminalConfig.writeConfigFile(settings: settings)
         XCTAssertNotNil(path, "Config file write should return a path")
     }
 
     func testWrittenFileContainsExpectedKeys() throws {
-        guard let path = TerminalConfig.writeConfigFile(settings: settings) else {
-            XCTFail("Config file write returned nil")
-            return
-        }
+        let path = try TerminalConfig.writeConfigFile(settings: settings)
         let contents = try String(contentsOfFile: path, encoding: .utf8)
 
         XCTAssertTrue(contents.contains("font-family"), "Config should contain font-family")
@@ -43,6 +40,8 @@ final class TerminalConfigTests: XCTestCase {
         XCTAssertTrue(contents.contains("shell-integration-features"), "Config should declare shell integration features")
         XCTAssertTrue(contents.contains("link-url = true"), "Config should enable clickable links")
         XCTAssertTrue(contents.contains("keybind = clear"), "Config should clear keybinds")
+        XCTAssertTrue(contents.contains("window-padding-y = 38"), "Config should write the expected vertical padding")
+        XCTAssertFalse(contents.contains("window-padding-y = 38,2"), "Config should not include the old typo")
     }
 
     func testWrittenFileReflectsCurrentSettings() throws {
@@ -52,10 +51,7 @@ final class TerminalConfigTests: XCTestCase {
         settings.shellIntegrationCursor = false
         settings.shellIntegrationSSHTerminfo = true
 
-        guard let path = TerminalConfig.writeConfigFile(settings: settings) else {
-            XCTFail("Config file write returned nil")
-            return
-        }
+        let path = try TerminalConfig.writeConfigFile(settings: settings)
         let contents = try String(contentsOfFile: path, encoding: .utf8)
 
         XCTAssertTrue(contents.contains("font-family = \(settings.fontFamily)"),
@@ -73,12 +69,45 @@ final class TerminalConfigTests: XCTestCase {
     func testDisabledShellIntegrationWritesNone() throws {
         settings.shellIntegrationEnabled = false
 
-        guard let path = TerminalConfig.writeConfigFile(settings: settings) else {
-            XCTFail("Config file write returned nil")
-            return
-        }
+        let path = try TerminalConfig.writeConfigFile(settings: settings)
         let contents = try String(contentsOfFile: path, encoding: .utf8)
 
         XCTAssertTrue(contents.contains("shell-integration = none"))
+    }
+
+    func testWriteConfigFileThrowsForInvalidDirectory() throws {
+        let invalidDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalConfigTests-\(UUID().uuidString).txt")
+        try "not a directory".write(to: invalidDirectory, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: invalidDirectory) }
+
+        XCTAssertThrowsError(try TerminalConfig.writeConfigFile(
+            settings: settings,
+            configurationDirectory: invalidDirectory
+        )) { error in
+            guard let terminalError = error as? TerminalConfigError else {
+                return XCTFail("Expected TerminalConfigError, got \(error)")
+            }
+            guard case .failedToCreateConfigDirectory(let url, _) = terminalError else {
+                return XCTFail("Expected failedToCreateConfigDirectory, got \(terminalError)")
+            }
+            XCTAssertEqual(url, invalidDirectory)
+        }
+    }
+
+    func testInitializationCapturesConfigWriteFailures() throws {
+        let invalidDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalConfigTests-\(UUID().uuidString).txt")
+        try "not a directory".write(to: invalidDirectory, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: invalidDirectory) }
+
+        let config = TerminalConfig(configurationDirectory: invalidDirectory)
+        XCTAssertNotNil(config.config, "Ghostty config object should still be created")
+        XCTAssertNotNil(config.configurationError, "Initializer should retain the write failure for callers")
+        if case .some(.failedToCreateConfigDirectory(let url, _)) = config.configurationError {
+            XCTAssertEqual(url, invalidDirectory)
+        } else {
+            XCTFail("Expected failedToCreateConfigDirectory")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- surface critical startup and configuration failures with native alerts
- propagate terminal config write errors and fix the window padding typo
- remove inactive Undo/Redo menu items and cover config writing with tests

Closes #10
Closes #11
Closes #19
Closes #21