### PR TITLE
fix(ui): clean up drop temp files and remove stub hooks

### DIFF
--- a/Bellith/App/AppDelegate.swift
+++ b/Bellith/App/AppDelegate.swift
@@ -602,17 +602,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return true
 
         case GHOSTTY_ACTION_MOUSE_OVER_LINK:
-            let link = action.action.mouse_over_link
-            if link.len > 0, let url = link.url {
-                let urlStr = String(cString: url)
-                if target.tag == GHOSTTY_TARGET_SURFACE,
-                   let surfaceUD = ghostty_surface_userdata(target.target.surface) {
-                    let surfaceView = Unmanaged<TerminalSurfaceView>.fromOpaque(surfaceUD).takeUnretainedValue()
-                    container(for: surfaceView)?.showLinkPreview(urlStr)
-                }
-            } else {
-                activeEntry?.container.hideLinkPreview()
-            }
             return true
 
         case GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL:
@@ -658,14 +647,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return true
 
         case GHOSTTY_ACTION_SCROLLBAR:
-            let bar = action.action.scrollbar
-            if target.tag == GHOSTTY_TARGET_SURFACE,
-               let surfaceUD = ghostty_surface_userdata(target.target.surface) {
-                let surfaceView = Unmanaged<TerminalSurfaceView>.fromOpaque(surfaceUD).takeUnretainedValue()
-                container(for: surfaceView)?.updateScrollbar(
-                    total: bar.total, offset: bar.offset, visible: bar.len
-                )
-            }
             return true
 
         case GHOSTTY_ACTION_START_SEARCH:

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -1898,16 +1898,6 @@ final class TerminalContainerView: NSView {
         }
     }
 
-    // MARK: - Link Preview
-
-    func showLinkPreview(_ url: String) {
-        // TODO: implement link preview tooltip
-    }
-
-    func hideLinkPreview() {
-        // TODO: hide link preview tooltip
-    }
-
     // MARK: - Font Size
 
     func adjustFontSizePublic(delta: Int) { adjustFontSize(delta: delta) }
@@ -1933,12 +1923,6 @@ final class TerminalContainerView: NSView {
         let config = TerminalConfig()
         guard let newConfig = config.config else { return }
         ghostty_app_update_config(app, newConfig)
-    }
-
-    // MARK: - Scrollbar
-
-    func updateScrollbar(total: UInt64, offset: UInt64, visible: UInt64) {
-        // TODO: implement scrollbar overlay
     }
 
     // MARK: - Session Save / Restore

--- a/Bellith/Views/TerminalSurfaceView.swift
+++ b/Bellith/Views/TerminalSurfaceView.swift
@@ -15,6 +15,7 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
     private var eventMonitor: Any?
     private var focused = false
     private let dropIndicatorLayer = CALayer()
+    private let temporaryDropDirectoryURL = TerminalSurfaceView.temporaryDropDirectoryURL()
 
     /// Called when the shell process exits or the surface requests close.
     var onClose: ((Bool) -> Void)?
@@ -73,6 +74,7 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
     required init?(coder: NSCoder) { fatalError() }
 
     deinit {
+        Self.cleanupTemporaryDropDirectory(at: temporaryDropDirectoryURL)
         if let eventMonitor { NSEvent.removeMonitor(eventMonitor) }
         if let surface { ghostty_surface_free(surface) }
     }
@@ -260,12 +262,13 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
     }
 
     private func writeTemporaryImageData(_ data: Data, fileExtension: String) -> URL? {
-        let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-            .appendingPathComponent("BellithDrops", isDirectory: true)
-
         do {
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
-            let fileURL = directory.appendingPathComponent("image-\(UUID().uuidString).\(fileExtension)")
+            try FileManager.default.createDirectory(
+                at: temporaryDropDirectoryURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            let fileURL = Self.temporaryDropImageURL(in: temporaryDropDirectoryURL, fileExtension: fileExtension)
             try data.write(to: fileURL, options: .atomic)
             return fileURL
         } catch {
@@ -289,6 +292,21 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
     private static func shellQuoted(_ path: String) -> String {
         let escaped = path.replacingOccurrences(of: "'", with: "'\\''")
         return "'\(escaped)'"
+    }
+
+    static func temporaryDropDirectoryURL(baseDirectory: URL = FileManager.default.temporaryDirectory) -> URL {
+        baseDirectory
+            .appendingPathComponent("BellithDrops", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
+
+    static func temporaryDropImageURL(in directory: URL, fileExtension: String) -> URL {
+        directory.appendingPathComponent("image-\(UUID().uuidString).\(fileExtension)")
+    }
+
+    static func cleanupTemporaryDropDirectory(at directory: URL, fileManager: FileManager = .default) {
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        try? fileManager.removeItem(at: directory)
     }
 
     // MARK: - Keyboard

--- a/BellithTests/TerminalSurfaceViewTests.swift
+++ b/BellithTests/TerminalSurfaceViewTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+@testable import Bellith
+
+final class TerminalSurfaceViewTests: XCTestCase {
+    func testTemporaryDropDirectoryURLLivesUnderSystemTempDirectory() {
+        let baseDirectory = URL(fileURLWithPath: "/tmp/test-base", isDirectory: true)
+
+        let directory = TerminalSurfaceView.temporaryDropDirectoryURL(baseDirectory: baseDirectory)
+
+        XCTAssertEqual(directory.deletingLastPathComponent().deletingLastPathComponent(), baseDirectory)
+        XCTAssertEqual(directory.deletingLastPathComponent().lastPathComponent, "BellithDrops")
+    }
+
+    func testTemporaryDropImageURLUsesRequestedExtension() {
+        let directory = URL(fileURLWithPath: "/tmp/BellithDrops/session", isDirectory: true)
+
+        let url = TerminalSurfaceView.temporaryDropImageURL(in: directory, fileExtension: "png")
+
+        XCTAssertEqual(url.deletingLastPathComponent(), directory)
+        XCTAssertEqual(url.pathExtension, "png")
+        XCTAssertTrue(url.lastPathComponent.hasPrefix("image-"))
+    }
+
+    func testCleanupTemporaryDropDirectoryRemovesDirectoryTree() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BellithTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let nestedFile = directory.appendingPathComponent("image.png")
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data([0x00, 0x01, 0x02]).write(to: nestedFile)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: nestedFile.path))
+
+        TerminalSurfaceView.cleanupTemporaryDropDirectory(at: directory)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+    }
+}


### PR DESCRIPTION
## Summary
- isolate dragged image temp files in per-surface temp directories and clean them up on deinit
- remove dead link-preview and scrollbar stub hooks from the Ghostty action path
- add focused tests for temp drop path generation and cleanup

Closes #9
Closes #12