### PR TITLE
feat(ui): show git worktree badges

### DIFF
--- a/Bellith/Views/StatusBarView.swift
+++ b/Bellith/Views/StatusBarView.swift
@@ -9,6 +9,7 @@ final class StatusBarView: NSView {
     // Left items
     private let hostBadge = ContextBadgeView()
     private let environmentBadge = ContextBadgeView()
+    private let worktreeBadge = ContextBadgeView()
     private let cwdIcon = NSImageView()
     private let cwdLabel = NSTextField(labelWithString: "~")
     private let separator1 = NSTextField(labelWithString: "·")
@@ -48,6 +49,9 @@ final class StatusBarView: NSView {
 
         environmentBadge.isHidden = true
         addSubview(environmentBadge)
+
+        worktreeBadge.isHidden = true
+        addSubview(worktreeBadge)
 
         setupIcon(cwdIcon, symbol: "folder.fill", tint: Theme.accent)
         setupLabel(cwdLabel, size: 12, weight: .medium, color: Theme.textPrimary)
@@ -110,6 +114,8 @@ final class StatusBarView: NSView {
         guard let context else {
             hostBadge.text = ""
             environmentBadge.text = ""
+            worktreeBadge.text = ""
+            worktreeBadge.iconName = nil
             needsLayout = true
             return
         }
@@ -127,6 +133,15 @@ final class StatusBarView: NSView {
             environmentBadge.iconName = nil
         }
 
+        needsLayout = true
+    }
+
+    func updateGitWorktree(_ worktreeName: String?) {
+        let normalizedName = worktreeName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = (normalizedName?.isEmpty == false) ? normalizedName : nil
+        worktreeBadge.text = value ?? ""
+        worktreeBadge.iconName = value == nil ? nil : "folder.badge.gearshape"
+        worktreeBadge.tone = .neutral
         needsLayout = true
     }
 
@@ -202,6 +217,7 @@ final class StatusBarView: NSView {
         updateContext(nil)
         cwdLabel.stringValue = "~"
         updateGitBranch(nil)
+        updateGitWorktree(nil)
         updateProcess(nil)
         sizeLabel.stringValue = ""
         sizeCapsule.isHidden = true
@@ -240,6 +256,14 @@ final class StatusBarView: NSView {
             x += badgeSize.width + 10
         } else {
             environmentBadge.frame = .zero
+        }
+
+        if !worktreeBadge.isHidden {
+            let badgeSize = worktreeBadge.intrinsicContentSize
+            worktreeBadge.frame = NSRect(x: x, y: (h - badgeSize.height) / 2, width: badgeSize.width, height: badgeSize.height)
+            x += badgeSize.width + 8
+        } else {
+            worktreeBadge.frame = .zero
         }
 
         // CWD
@@ -297,6 +321,7 @@ final class StatusBarView: NSView {
         sizeCapsule.layer?.borderColor = Theme.chromeHairline.cgColor
         hostBadge.refreshTheme()
         environmentBadge.refreshTheme()
+        worktreeBadge.refreshTheme()
         cwdIcon.contentTintColor = Theme.accent
         cwdLabel.textColor = Theme.textPrimary
         separator1.textColor = Theme.textMuted.withAlphaComponent(0.5)

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -3,6 +3,12 @@ import GhosttyKit
 import QuartzCore
 import os
 
+struct GitRepositoryInfo: Equatable {
+    let branch: String?
+    let worktreeName: String?
+    let isWorktree: Bool
+}
+
 /// Container that hosts multiple terminal tabs (each with optional split panes),
 /// smart inspector tabs, a sidebar or tab bar, and the command palette.
 final class TerminalContainerView: NSView {
@@ -655,7 +661,11 @@ final class TerminalContainerView: NSView {
             statusBar.updateCwd(initialCwd)
             titleBar.updatePath(initialCwd)
             titleBar.updateGitBranch(nil)
+            titleBar.updateGitWorktree(nil)
             titleBar.updateProcess(nil)
+            statusBar.updateGitBranch(nil)
+            statusBar.updateGitWorktree(nil)
+            statusBar.updateProcess(nil)
             refreshStatusBarAsync(cwd: initialCwd)
         }
 
@@ -821,17 +831,21 @@ final class TerminalContainerView: NSView {
             titleBar.updatePath(entry.cwd)
             if let cwd = entry.cwd {
                 titleBar.updateGitBranch(nil)
+                titleBar.updateGitWorktree(nil)
                 titleBar.updateProcess(nil)
                 statusBar.updateCwd(cwd)
                 statusBar.updateGitBranch(nil)
+                statusBar.updateGitWorktree(nil)
                 statusBar.updateProcess(nil)
                 refreshStatusBarAsync(cwd: cwd)
             } else {
                 titleBar.updateGitBranch(nil)
+                titleBar.updateGitWorktree(nil)
                 titleBar.updateProcess(nil)
                 statusBar.updateContext(context)
                 statusBar.updateCwd(nil)
                 statusBar.updateGitBranch(nil)
+                statusBar.updateGitWorktree(nil)
                 statusBar.updateProcess(nil)
             }
             sidebar.setActiveToolID(nil)
@@ -841,6 +855,7 @@ final class TerminalContainerView: NSView {
             titleBar.updateContext(nil)
             titleBar.updatePath(nil)
             titleBar.updateGitBranch(nil)
+            titleBar.updateGitWorktree(nil)
             titleBar.updateProcess(nil)
             titleBar.clearSize()
             statusBar.clear()
@@ -872,9 +887,11 @@ final class TerminalContainerView: NSView {
                 statusBar.updateContext(surface.displayContext)
                 titleBar.updatePath(cwd)
                 titleBar.updateGitBranch(nil)
+                titleBar.updateGitWorktree(nil)
                 titleBar.updateProcess(nil)
                 statusBar.updateCwd(cwd)
                 statusBar.updateGitBranch(nil)
+                statusBar.updateGitWorktree(nil)
                 statusBar.updateProcess(nil)
                 refreshStatusBarAsync(cwd: cwd)
             }
@@ -887,8 +904,7 @@ final class TerminalContainerView: NSView {
         let pid = findShellPID()
         let activeSurface = activeSurface
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            // Git branch
-            let branch = Self.gitBranch(in: cwd)
+            let gitInfo = Self.gitRepositoryInfo(in: cwd)
             let runtimeStatus = Self.runtimeStatus(for: pid)
 
             DispatchQueue.main.async {
@@ -901,10 +917,12 @@ final class TerminalContainerView: NSView {
                     self.titleBar.updateContext(context)
                     self.statusBar.updateContext(context)
                 }
-                self.titleBar.updateGitBranch(branch)
+                self.titleBar.updateGitBranch(gitInfo?.branch)
+                self.titleBar.updateGitWorktree(gitInfo?.worktreeName)
                 self.titleBar.updateProcess(runtimeStatus.foregroundProcess)
                 self.statusBar.updateCwd(cwd)
-                self.statusBar.updateGitBranch(branch)
+                self.statusBar.updateGitBranch(gitInfo?.branch)
+                self.statusBar.updateGitWorktree(gitInfo?.worktreeName)
                 self.statusBar.updateProcess(runtimeStatus.foregroundProcess)
             }
         }
@@ -961,20 +979,55 @@ final class TerminalContainerView: NSView {
         return RuntimeStatus(foregroundProcess: foregroundName, detectedContext: detectedContext)
     }
 
-    private static func gitBranch(in directory: String) -> String? {
+    static func gitRepositoryInfo(in directory: String) -> GitRepositoryInfo? {
         let pipe = Pipe()
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-        process.arguments = ["-C", directory, "branch", "--show-current"]
+        process.arguments = [
+            "-C", directory,
+            "rev-parse",
+            "--abbrev-ref", "HEAD",
+            "--git-dir",
+            "--git-common-dir",
+            "--show-toplevel",
+        ]
         process.standardOutput = pipe
         process.standardError = FileHandle.nullDevice
         do {
             try process.run()
             process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
-            return output?.isEmpty == false ? output : nil
+            let output = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let output, !output.isEmpty else { return nil }
+
+            let lines = output.components(separatedBy: .newlines)
+            guard lines.count >= 4 else { return nil }
+
+            let branch = normalizedGitOutput(lines[0])
+            let gitDir = resolvedGitURL(for: lines[1], relativeTo: directory)
+            let commonDir = resolvedGitURL(for: lines[2], relativeTo: directory)
+            let topLevel = resolvedGitURL(for: lines[3], relativeTo: directory)
+            let isWorktree = gitDir.resolvingSymlinksInPath().path != commonDir.resolvingSymlinksInPath().path
+            let worktreeName = isWorktree ? topLevel.lastPathComponent : nil
+            return GitRepositoryInfo(branch: branch, worktreeName: worktreeName, isWorktree: isWorktree)
         } catch { return nil }
+    }
+
+    private static func resolvedGitURL(for path: String, relativeTo directory: String) -> URL {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("/") {
+            return URL(fileURLWithPath: trimmed).standardizedFileURL
+        }
+        return URL(fileURLWithPath: directory, isDirectory: true)
+            .appendingPathComponent(trimmed)
+            .standardizedFileURL
+    }
+
+    private static func normalizedGitOutput(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func persistedContext(for entry: TabEntry) -> TerminalContext? {
@@ -2190,9 +2243,11 @@ final class TerminalContainerView: NSView {
                 statusBar.updateContext(surface.displayContext)
                 titleBar.updatePath(cwd)
                 titleBar.updateGitBranch(nil)
+                titleBar.updateGitWorktree(nil)
                 titleBar.updateProcess(nil)
                 statusBar.updateCwd(cwd)
                 statusBar.updateGitBranch(nil)
+                statusBar.updateGitWorktree(nil)
                 statusBar.updateProcess(nil)
                 refreshStatusBarAsync(cwd: cwd)
             }

--- a/Bellith/Views/TitleBarView.swift
+++ b/Bellith/Views/TitleBarView.swift
@@ -20,6 +20,7 @@ final class TitleBarView: NSView {
     private let folderIcon = NSImageView()
     private let hostBadge = ContextBadgeView()
     private let environmentBadge = ContextBadgeView()
+    private let worktreeBadge = ContextBadgeView()
     private let gitIcon = NSImageView()
     private let gitLabel = NSTextField(labelWithString: "")
     private let processIcon = NSImageView()
@@ -72,6 +73,9 @@ final class TitleBarView: NSView {
 
         environmentBadge.isHidden = true
         addSubview(environmentBadge)
+
+        worktreeBadge.isHidden = true
+        addSubview(worktreeBadge)
 
         gitIcon.image = NSImage(systemSymbolName: "arrow.triangle.branch", accessibilityDescription: nil)
         gitIcon.imageScaling = .scaleProportionallyDown
@@ -160,6 +164,8 @@ final class TitleBarView: NSView {
         guard let context else {
             hostBadge.text = ""
             environmentBadge.text = ""
+            worktreeBadge.text = ""
+            worktreeBadge.iconName = nil
             needsLayout = true
             return
         }
@@ -177,6 +183,15 @@ final class TitleBarView: NSView {
             environmentBadge.iconName = nil
         }
 
+        needsLayout = true
+    }
+
+    func updateGitWorktree(_ worktreeName: String?) {
+        let normalizedName = worktreeName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = (normalizedName?.isEmpty == false) ? normalizedName : nil
+        worktreeBadge.text = value ?? ""
+        worktreeBadge.iconName = value == nil ? nil : "folder.badge.gearshape"
+        worktreeBadge.tone = .neutral
         needsLayout = true
     }
 
@@ -335,6 +350,14 @@ final class TitleBarView: NSView {
             environmentBadge.frame = .zero
         }
 
+        if !worktreeBadge.isHidden {
+            let size = worktreeBadge.intrinsicContentSize
+            worktreeBadge.frame = NSRect(x: x, y: floor((h - size.height) / 2), width: size.width, height: size.height)
+            x += size.width + 10
+        } else {
+            worktreeBadge.frame = .zero
+        }
+
         folderIcon.frame = NSRect(x: x, y: floor((h - iconSize) / 2), width: iconSize, height: iconSize)
         x += iconSize + gap + 1
 
@@ -396,6 +419,7 @@ final class TitleBarView: NSView {
         folderIcon.contentTintColor = Theme.textSecondary
         hostBadge.refreshTheme()
         environmentBadge.refreshTheme()
+        worktreeBadge.refreshTheme()
         gitIcon.contentTintColor = Theme.success
         gitLabel.textColor = Theme.textSecondary
         processIcon.contentTintColor = Theme.warning

--- a/BellithTests/GitRepositoryInfoTests.swift
+++ b/BellithTests/GitRepositoryInfoTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Bellith
+
+final class GitRepositoryInfoTests: XCTestCase {
+    func testGitRepositoryInfoDetectsLinkedWorktree() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent("BellithGitRepo-\(UUID().uuidString)", isDirectory: true)
+        let worktree = root.appendingPathComponent("feature-worktree", isDirectory: true)
+
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: root)
+        }
+
+        try runGit(["init"], in: root)
+        try runGit(["config", "user.name", "Bellith Tests"], in: root)
+        try runGit(["config", "user.email", "tests@example.com"], in: root)
+
+        let readme = root.appendingPathComponent("README.md")
+        try "initial".write(to: readme, atomically: true, encoding: .utf8)
+        try runGit(["add", "README.md"], in: root)
+        try runGit(["commit", "-m", "initial"], in: root)
+        try runGit(["worktree", "add", "-b", "feature", worktree.path], in: root)
+
+        let worktreeInfo = TerminalContainerView.gitRepositoryInfo(in: worktree.path)
+        XCTAssertEqual(worktreeInfo?.branch, "feature")
+        XCTAssertEqual(worktreeInfo?.worktreeName, "feature-worktree")
+        XCTAssertTrue(worktreeInfo?.isWorktree ?? false)
+
+        let rootInfo = TerminalContainerView.gitRepositoryInfo(in: root.path)
+        XCTAssertNotNil(rootInfo?.branch)
+        XCTAssertNil(rootInfo?.worktreeName)
+        XCTAssertFalse(rootInfo?.isWorktree ?? true)
+    }
+
+    private func runGit(_ arguments: [String], in directory: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let stdout = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let stderr = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "GitRepositoryInfoTests",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed: \(stdout) \(stderr)"]
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- detect when the active cwd is inside a git worktree
- surface the worktree name in the title bar and status bar
- add repository info tests covering linked worktree detection

Closes #7