### PR TITLE
test(ui): expand split pane and palette coverage

### DIFF
--- a/Bellith/Views/CommandPaletteView.swift
+++ b/Bellith/Views/CommandPaletteView.swift
@@ -196,7 +196,7 @@ final class CommandPaletteView: NSView {
     // MARK: - Results
 
     /// Fuzzy match score — returns nil if no match, higher score = better match
-    private static func fuzzyScore(query: String, target: String) -> Int? {
+    static func fuzzyScore(query: String, target: String) -> Int? {
         guard !query.isEmpty else { return 0 }
         let queryChars = Array(query.lowercased())
         let targetChars = Array(target.lowercased())
@@ -219,12 +219,13 @@ final class CommandPaletteView: NSView {
     }
 
     /// Shared filtering logic — returns commands ranked by fuzzy relevance.
-    private static func filteredCommands(for query: String, limit: Int) -> [CommandItem] {
+    static func filteredCommands(for query: String, limit: Int, commands: [CommandItem]? = nil) -> [CommandItem] {
+        let sourceCommands = commands ?? Self.commands
         if query.isEmpty {
-            return Array(commands.prefix(limit))
+            return Array(sourceCommands.prefix(limit))
         }
         var scored: [(cmd: CommandItem, score: Int)] = []
-        for cmd in commands {
+        for cmd in sourceCommands {
             if let labelScore = fuzzyScore(query: query, target: cmd.label) {
                 scored.append((cmd, labelScore + 10)) // Boost label matches
             } else if let idScore = fuzzyScore(query: query, target: cmd.id) {

--- a/BellithTests/CommandPaletteViewTests.swift
+++ b/BellithTests/CommandPaletteViewTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Bellith
+
+final class CommandPaletteViewTests: XCTestCase {
+    func testFuzzyScorePrefersConsecutiveMatches() {
+        XCTAssertNotNil(CommandPaletteView.fuzzyScore(query: "np", target: "New Pane"))
+        XCTAssertNil(CommandPaletteView.fuzzyScore(query: "zz", target: "New Pane"))
+    }
+
+    func testFilteredCommandsReturnsPrefixForEmptyQuery() {
+        let commands: [CommandPaletteView.CommandItem] = [
+            (id: "newTab", label: "New Tab", description: "Open a new terminal tab", icon: "plus.square", shortcutId: nil),
+            (id: "nextTerminal", label: "Next Terminal", description: "Move to the next terminal", icon: "arrow.right", shortcutId: nil),
+            (id: "reloadConfig", label: "Reload Config", description: "Reload terminal configuration", icon: "arrow.clockwise", shortcutId: nil),
+        ]
+
+        let filtered = CommandPaletteView.filteredCommands(for: "", limit: 2, commands: commands)
+
+        XCTAssertEqual(filtered.map(\.id), ["newTab", "nextTerminal"])
+    }
+
+    func testFilteredCommandsPrefersLabelMatchesOverIDMatches() {
+        let commands: [CommandPaletteView.CommandItem] = [
+            (id: "new-pane", label: "Preferences", description: "ID match only", icon: "slider.horizontal.3", shortcutId: nil),
+            (id: "pane-manager", label: "New Pane", description: "Label match should rank first", icon: "plus.square", shortcutId: nil),
+        ]
+
+        let filtered = CommandPaletteView.filteredCommands(for: "new", limit: 3, commands: commands)
+
+        XCTAssertEqual(filtered.first?.id, "pane-manager")
+    }
+
+    func testFilteredCommandsReturnsNoResultsForUnmatchedQuery() {
+        let commands: [CommandPaletteView.CommandItem] = [
+            (id: "newTab", label: "New Tab", description: "Open a new terminal tab", icon: "plus.square", shortcutId: nil),
+            (id: "nextTerminal", label: "Next Terminal", description: "Move to the next terminal", icon: "arrow.right", shortcutId: nil),
+            (id: "reloadConfig", label: "Reload Config", description: "Reload terminal configuration", icon: "arrow.clockwise", shortcutId: nil),
+        ]
+
+        let filtered = CommandPaletteView.filteredCommands(for: "zzzz-unmatched", limit: 3, commands: commands)
+
+        XCTAssertTrue(filtered.isEmpty)
+    }
+}

--- a/BellithTests/SplitPaneViewTests.swift
+++ b/BellithTests/SplitPaneViewTests.swift
@@ -1,0 +1,98 @@
+import AppKit
+import XCTest
+@testable import Bellith
+
+final class SplitPaneViewTests: XCTestCase {
+    func testSplitCreatesBranchWithTwoLeaves() {
+        let firstView = NSView()
+        let secondView = NSView()
+        let root = SplitPaneView(content: firstView)
+
+        let newLeaf = root.split(orientation: .vertical, newContent: secondView)
+
+        XCTAssertFalse(root.isLeaf)
+        XCTAssertEqual(root.allLeaves.count, 2)
+        XCTAssertTrue(root.allLeaves.contains { $0 === firstView })
+        XCTAssertTrue(root.allLeaves.contains { $0 === secondView })
+        XCTAssertTrue(newLeaf.contentView === secondView)
+    }
+
+    func testRemoveChildCollapsesBranchBackToLeaf() {
+        let firstView = NSView()
+        let secondView = NSView()
+        let root = SplitPaneView(content: firstView)
+        _ = root.split(orientation: .vertical, newContent: secondView)
+
+        guard let secondLeaf = root.leaf(containing: secondView) else {
+            return XCTFail("Expected to find the second split leaf")
+        }
+
+        root.removeChild(secondLeaf)
+
+        XCTAssertTrue(root.isLeaf)
+        XCTAssertTrue(root.contentView === firstView)
+        XCTAssertEqual(root.allLeaves.count, 1)
+    }
+
+    func testAdjacentLeafFindsSiblingAcrossVerticalSplit() {
+        let leftView = NSView()
+        let rightView = NSView()
+        let root = SplitPaneView(content: leftView)
+        _ = root.split(orientation: .vertical, newContent: rightView)
+
+        XCTAssertTrue(root.adjacentLeaf(from: leftView, direction: .right) === rightView)
+        XCTAssertTrue(root.adjacentLeaf(from: rightView, direction: .left) === leftView)
+    }
+
+    func testAdjustRatioClampsToBounds() {
+        let root = SplitPaneView(content: NSView())
+        _ = root.split(orientation: .horizontal, newContent: NSView())
+
+        root.adjustRatio(by: 10)
+        XCTAssertEqual(root.currentRatio, 0.85, accuracy: 0.0001)
+
+        root.adjustRatio(by: -10)
+        XCTAssertEqual(root.currentRatio, 0.15, accuracy: 0.0001)
+    }
+
+    func testSerializeProducesNestedBranchState() {
+        let firstView = NSView()
+        let secondView = NSView()
+        let thirdView = NSView()
+        let root = SplitPaneView(content: firstView)
+        let secondLeaf = root.split(orientation: .vertical, newContent: secondView)
+        _ = secondLeaf.split(orientation: .horizontal, newContent: thirdView)
+
+        let serialized = root.serialize { view in
+            if view === firstView { return "/one" }
+            if view === secondView { return "/two" }
+            if view === thirdView { return "/three" }
+            return nil
+        }
+
+        guard case .branch(let orientation, _, let first, let second) = serialized else {
+            return XCTFail("Expected a branch root state")
+        }
+        XCTAssertEqual(orientation, "vertical")
+
+        guard case .leaf(let firstCwd) = first else {
+            return XCTFail("Expected first child leaf")
+        }
+        XCTAssertEqual(firstCwd, "/one")
+
+        guard case .branch(let nestedOrientation, _, let nestedFirst, let nestedSecond) = second else {
+            return XCTFail("Expected nested branch")
+        }
+        XCTAssertEqual(nestedOrientation, "horizontal")
+
+        guard case .leaf(let nestedFirstCwd) = nestedFirst else {
+            return XCTFail("Expected nested first leaf")
+        }
+        XCTAssertEqual(nestedFirstCwd, "/two")
+
+        guard case .leaf(let nestedSecondCwd) = nestedSecond else {
+            return XCTFail("Expected nested second leaf")
+        }
+        XCTAssertEqual(nestedSecondCwd, "/three")
+    }
+}


### PR DESCRIPTION
Closes #16\n\nAdds focused coverage for SplitPaneView tree operations and CommandPalette filtering helpers, with only minimal production exposure to make the filtering logic testable.\n\nVerification:\n- xcodebuild -project Bellith.xcodeproj -scheme Bellith -configuration Debug -derivedDataPath /tmp/bellith-dd-16 build\n- xcodebuild -project Bellith.xcodeproj -scheme Bellith -configuration Debug -derivedDataPath /tmp/bellith-dd-16 test -only-testing:BellithTests/SplitPaneViewTests -only-testing:BellithTests/CommandPaletteViewTests (compiled, then failed at com.apple.testmanagerd sandbox access in this environment)