### PR TITLE
fix(ui): extract named constants for layout values

### DIFF
--- a/Bellith/Views/SmartPanels/SmartPanelView.swift
+++ b/Bellith/Views/SmartPanels/SmartPanelView.swift
@@ -85,6 +85,13 @@ final class SmartPanelRegistry {
 /// Base class for smart (non-terminal) tab panels.
 /// Provides a frosted header bar, scrollable content area, and a refresh timer.
 class SmartPanelView: NSView {
+    private enum Metrics {
+        static let headerHeight: CGFloat = 36
+        static let headerIconSize: CGFloat = 14
+        static let headerLabelHeight: CGFloat = 16
+        static let defaultRefreshInterval: TimeInterval = 2.0
+    }
+
     let pluginID: String
     let panelTitle: String
     let panelIconName: String
@@ -168,15 +175,13 @@ class SmartPanelView: NSView {
 
     // MARK: - Layout
 
-    private let headerHeight: CGFloat = 36
-
     override func layout() {
         super.layout()
         if showsHeader {
-            headerView.frame = NSRect(x: 0, y: bounds.height - headerHeight, width: bounds.width, height: headerHeight)
-            headerIcon.frame = NSRect(x: 12, y: (headerHeight - 14) / 2, width: 14, height: 14)
-            headerLabel.frame = NSRect(x: 32, y: (headerHeight - 16) / 2, width: bounds.width - 44, height: 16)
-            scrollView.frame = NSRect(x: 0, y: 0, width: bounds.width, height: bounds.height - headerHeight)
+            headerView.frame = NSRect(x: 0, y: bounds.height - Metrics.headerHeight, width: bounds.width, height: Metrics.headerHeight)
+            headerIcon.frame = NSRect(x: 12, y: (Metrics.headerHeight - Metrics.headerIconSize) / 2, width: Metrics.headerIconSize, height: Metrics.headerIconSize)
+            headerLabel.frame = NSRect(x: 32, y: (Metrics.headerHeight - Metrics.headerLabelHeight) / 2, width: bounds.width - 44, height: Metrics.headerLabelHeight)
+            scrollView.frame = NSRect(x: 0, y: 0, width: bounds.width, height: bounds.height - Metrics.headerHeight)
         } else {
             scrollView.frame = bounds
         }
@@ -192,7 +197,7 @@ class SmartPanelView: NSView {
     func refresh() {}
 
     /// Start the periodic refresh timer (call when the tab becomes visible).
-    func startRefreshing(interval: TimeInterval = 2.0) {
+    func startRefreshing(interval: TimeInterval = Metrics.defaultRefreshInterval) {
         guard !isActive else { return }
         isActive = true
         refresh()

--- a/Bellith/Views/SplitPaneView.swift
+++ b/Bellith/Views/SplitPaneView.swift
@@ -5,6 +5,12 @@ import AppKit
 final class SplitPaneView: NSView {
     enum Orientation { case horizontal, vertical }
 
+    private enum Metrics {
+        static let defaultSplitRatio: CGFloat = 0.5
+        static let minSplitRatio: CGFloat = 0.15
+        static let maxSplitRatio: CGFloat = 0.85
+    }
+
     // Leaf state
     private(set) var contentView: NSView?
 
@@ -50,7 +56,7 @@ final class SplitPaneView: NSView {
         existing.removeFromSuperview()
 
         self.orientation = orientation
-        self.ratio = 0.5
+        self.ratio = Metrics.defaultSplitRatio
 
         let firstChild = SplitPaneView(content: existing)
         firstChild.onFocusChanged = onFocusChanged
@@ -249,7 +255,7 @@ final class SplitPaneView: NSView {
     }
 
     func adjustRatio(by delta: CGFloat, animated: Bool = false) {
-        ratio = min(0.85, max(0.15, ratio + delta))
+        ratio = min(Metrics.maxSplitRatio, max(Metrics.minSplitRatio, ratio + delta))
         if animated {
             animateLayout(duration: Theme.animFast)
         } else {
@@ -405,7 +411,7 @@ final class SplitPaneView: NSView {
         guard total > 0 else { return }
 
         let newRatio = ratio + delta / total
-        ratio = min(0.85, max(0.15, newRatio))
+        ratio = min(Metrics.maxSplitRatio, max(Metrics.minSplitRatio, newRatio))
         needsLayout = true
     }
 }

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -12,6 +12,12 @@ struct GitRepositoryInfo: Equatable {
 /// Container that hosts multiple terminal tabs (each with optional split panes),
 /// smart inspector tabs, a sidebar or tab bar, and the command palette.
 final class TerminalContainerView: NSView {
+    private enum Metrics {
+        static let runtimeRefreshInterval: TimeInterval = 1.0
+        static let minimumFontSize: Int = 8
+        static let maximumFontSize: Int = 36
+    }
+
     private weak var terminalApp: TerminalApp?
 
     enum TabContent {
@@ -400,7 +406,7 @@ final class TerminalContainerView: NSView {
     }
 
     private func startContextRefreshTimer() {
-        let timer = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: Metrics.runtimeRefreshInterval, repeats: true) { [weak self] _ in
             self?.refreshActiveRuntimeStatusIfNeeded()
         }
         contextRefreshTimer = timer
@@ -2007,7 +2013,7 @@ final class TerminalContainerView: NSView {
 
     private func adjustFontSize(delta: Int) {
         let settings = BellithSettings.shared
-        let newSize = max(8, min(36, settings.fontSize + delta))
+        let newSize = max(Metrics.minimumFontSize, min(Metrics.maximumFontSize, settings.fontSize + delta))
         guard newSize != settings.fontSize else { return }
         settings.fontSize = newSize
         reloadConfig()

--- a/Bellith/Views/TerminalWindow.swift
+++ b/Bellith/Views/TerminalWindow.swift
@@ -10,6 +10,20 @@ final class TerminalWindow: NSWindow {
         case forcedHidden
     }
 
+    private enum Metrics {
+        static let autoHideDelay: TimeInterval = 2.0
+        static let automaticTrackingOriginX: CGFloat = 0
+        static let automaticTrackingWidth: CGFloat = 120
+        static let forcedTrackingOriginX: CGFloat = 8
+        static let forcedTrackingWidth: CGFloat = 164
+        static let automaticOriginX: CGFloat = 14
+        static let forcedOriginX: CGFloat = 16
+        static let automaticOriginYOffset: CGFloat = -1
+        static let forcedOriginYOffset: CGFloat = 2
+        static let automaticSpacing: CGFloat = 6
+        static let forcedSpacing: CGFloat = 6.5
+    }
+
     private var trafficLightTrackingArea: NSTrackingArea?
     private var trafficLightHideTimer: Timer?
     private var trafficLightsVisible = true
@@ -89,7 +103,7 @@ final class TerminalWindow: NSWindow {
     private func scheduleTrafficLightHide() {
         guard trafficLightDisplayMode == .automatic, shouldAutoHideTrafficLights else { return }
         trafficLightHideTimer?.invalidate()
-        trafficLightHideTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
+        trafficLightHideTimer = Timer.scheduledTimer(withTimeInterval: Metrics.autoHideDelay, repeats: false) { [weak self] _ in
             self?.hideTrafficLights()
         }
     }
@@ -188,8 +202,8 @@ final class TerminalWindow: NSWindow {
             contentView.removeTrackingArea(existing)
         }
 
-        let trackingOriginX: CGFloat = trafficLightDisplayMode == .automatic ? 0 : 8
-        let trackingWidth: CGFloat = trafficLightDisplayMode == .automatic ? 120 : 164
+        let trackingOriginX: CGFloat = trafficLightDisplayMode == .automatic ? Metrics.automaticTrackingOriginX : Metrics.forcedTrackingOriginX
+        let trackingWidth: CGFloat = trafficLightDisplayMode == .automatic ? Metrics.automaticTrackingWidth : Metrics.forcedTrackingWidth
         let trackingRect = NSRect(x: trackingOriginX, y: contentView.bounds.height - 64, width: trackingWidth, height: 64)
         let area = NSTrackingArea(
             rect: trackingRect,
@@ -210,9 +224,9 @@ final class TerminalWindow: NSWindow {
         let buttons = [close, mini, zoom]
         let buttonHeight = close.frame.height
         let usesSidebarPlacement = trafficLightDisplayMode != .automatic
-        let originY = round((container.bounds.height - buttonHeight) / 2) + (usesSidebarPlacement ? 2 : -1)
-        let originX: CGFloat = usesSidebarPlacement ? 16 : 14
-        let spacing: CGFloat = usesSidebarPlacement ? 6.5 : 6
+        let originY = round((container.bounds.height - buttonHeight) / 2) + (usesSidebarPlacement ? Metrics.forcedOriginYOffset : Metrics.automaticOriginYOffset)
+        let originX: CGFloat = usesSidebarPlacement ? Metrics.forcedOriginX : Metrics.automaticOriginX
+        let spacing: CGFloat = usesSidebarPlacement ? Metrics.forcedSpacing : Metrics.automaticSpacing
         var x = originX
 
         for button in buttons {


### PR DESCRIPTION
Extract the hard-coded split ratio, font-size bounds, traffic-light offsets, and timer intervals called out in issue #18 into named local constants. This is a readability-only cleanup with no intended behavior change. Closes #18.