### PR TITLE
refactor(ui): decompose terminal container view

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -8,7 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		00EC7090FE625A045A9BEF48 /* SSHProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359237193DE4C0621F16BDD8 /* SSHProfile.swift */; };
+		02C8AD21D19DCE280556463E /* TerminalSurfaceViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B019E37CE2B850357E2B7E /* TerminalSurfaceViewTests.swift */; };
 		0331E3E2063625C041EBDC40 /* TerminalConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254770B950E6ED2A7FF2ED56 /* TerminalConfigTests.swift */; };
+		03D3A8DFD8754842670312F9 /* TerminalOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E3FC50C1923C38393AB64D /* TerminalOverlayController.swift */; };
 		06F9811AE726F42DEB32D418 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9D96FFF53397D45EA101F4 /* PreferencesWindowController.swift */; };
 		0FF0294C8F9B14B9DBB9051F /* SplitPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB50294EC30FB94671823CFA /* SplitPaneView.swift */; };
 		11073F73D52E0F9CEAFB4FB5 /* TerminalWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973180A10E7387D33EBEA8DC /* TerminalWindow.swift */; };
@@ -19,6 +21,7 @@
 		1FE6195879EE4D4D65B24CC1 /* KeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB945FE301FBB1B34329681 /* KeyShortcutTests.swift */; };
 		200E6504867615A7339BFBC6 /* QuickTerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AD6AF9F8A70A7E83B56C8C /* QuickTerminalPane.swift */; };
 		2428C55AF2B4DC0234E13B04 /* PerformancePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A192597C4552FB866CD46BC9 /* PerformancePanel.swift */; };
+		27ADA01BC2482B15DEF1FEA8 /* TerminalContainerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A4045AB00706CFEF094251 /* TerminalContainerViewTests.swift */; };
 		2BC36AC2F4C1DD3823B68CA5 /* SSHSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9591082C7912641248227C8 /* SSHSessionDetector.swift */; };
 		2D7878CD0D5FB019A68AAA07 /* SessionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08540536C434953689D04D /* SessionStateTests.swift */; };
 		37CF1D9BB62D1BB55D63B0D0 /* TerminalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5966D19E6F059737E8B875 /* TerminalContext.swift */; };
@@ -27,6 +30,7 @@
 		3F067DBCA20A52FB30980DA2 /* SSHProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AC775F3A6A91CF3FE4CDAB /* SSHProfileStoreTests.swift */; };
 		3F81E95CDC0FF4142056C98A /* EnvironmentPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0B5E50A6BE76A1D3EDFE6D /* EnvironmentPanel.swift */; };
 		459FB063C7F788F4E0E549A5 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89FDA87579791818D3A6718 /* TerminalPane.swift */; };
+		462CADCA785D176937B5F445 /* GitRepositoryInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC203E445CE586B521D8FC29 /* GitRepositoryInfoTests.swift */; };
 		4859630C40EA72D0F6A13448 /* SSHLaunchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A6320778E024E8ABCDF2A6 /* SSHLaunchBuilder.swift */; };
 		4C6D7ECB973811FC8DA4121C /* ProcessMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A46EAB948FDDFB1C12E4B9 /* ProcessMonitor.swift */; };
 		4DDD96881F2A1409729CD580 /* HyperlinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2088BFA03DDDC079DE5DB8C /* HyperlinkRouter.swift */; };
@@ -41,10 +45,12 @@
 		8229F53686989E6007E9C7E9 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1055D889FA5B87C7B010166B /* ThemeTests.swift */; };
 		84920B35B7A5167C2AAE9985 /* BellithSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD22E965C6F1A921DC3AFFA /* BellithSettingsTests.swift */; };
 		88DF13E98F4C5539EFBCF58F /* NetworkPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B73776D795BE3450D431B7B /* NetworkPanel.swift */; };
+		8F9C4F38ABE6542683C89C38 /* SplitPaneViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E385EC194464E8BF67BE47B /* SplitPaneViewTests.swift */; };
 		941E77325C0B8A487B2CD650 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AF3EFCA4440E50031AF178C /* Logger.swift */; };
 		9BF5A978A5AACAB4DD91124B /* AboutPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6683BF4D86DE5BB7318C3C /* AboutPane.swift */; };
 		9EECDE6BE4882D41C3F53B22 /* SidebarPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33E81DDDC25CA709CD563AE /* SidebarPane.swift */; };
 		A0CFB54241CAA6006E58472C /* CommandRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8A3CDE542974BFD639F6F0 /* CommandRegistry.swift */; };
+		A381D1C113C9D8039615BCA4 /* TerminalRuntimeInfoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E1C3DB1ADB2A4903FA2FF2 /* TerminalRuntimeInfoService.swift */; };
 		A39350253246932A3A4CB068 /* KeybindingsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D1CA15561163656129EFFE /* KeybindingsPane.swift */; };
 		A4482FD8BE36A3CB5AB2CCC8 /* QuickTerminalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C964FC62608F8FA41EE01B5 /* QuickTerminalController.swift */; };
 		A497CDCB9182E12C715A1A43 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F6C0E62F0D6DFD08E3A8E5 /* AppDelegate.swift */; };
@@ -53,13 +59,16 @@
 		AA291915F73F4338FC1407C7 /* PreferencesPaneRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65ED0D10E5739FCA342E50A /* PreferencesPaneRegistry.swift */; };
 		AAEC14C4379EFD86E0A0BCCE /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69849D6EC718E0BFF019C9D8 /* TabBarView.swift */; };
 		B80E5D2747AB50B714189BC4 /* ProcessMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8932FC29FCA31DEBC5C25A11 /* ProcessMonitorTests.swift */; };
+		B91C9F9881E0670C71C5A556 /* TerminalSessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707A2AF28DE5D2F8EA639BFB /* TerminalSessionCoordinator.swift */; };
 		BAF7DA9CF2672F1E616A7F17 /* TitleBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5C94B09019221ED3984C56 /* TitleBarView.swift */; };
+		BD999453ED311F0651C106D3 /* TerminalTabModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693A40251EB6453D78EFD8E9 /* TerminalTabModel.swift */; };
 		BE00761441DEE5876F5AD1C8 /* SSHPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F589203C90A72C2C4DA09C /* SSHPane.swift */; };
 		CCA0508AE25C077D19B7319C /* BellithFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97FAFCF93CCB562713620EE /* BellithFont.swift */; };
 		CE826D24B9117475F5BFB14B /* BellithSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5E3E792593BBE98618983D /* BellithSettings.swift */; };
 		CF4A12A757D3355AEB4D159A /* AppearancePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFFF00A8FCA7C5D765650BD /* AppearancePane.swift */; };
 		D455B1DABDBE119547D39CE1 /* PreferencesComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BCA9A77D1E03020788D4D /* PreferencesComponents.swift */; };
 		D8094FD20E0D00F2DB1112D7 /* SSHSessionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EA413DA31A6997580EEAF8 /* SSHSessionDetectorTests.swift */; };
+		D976C2EC92ED3D33ECCB9882 /* CommandPaletteViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9994A85D37354E2BFF60705 /* CommandPaletteViewTests.swift */; };
 		D9B06ED212407C4E58B58CE2 /* TerminalConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E054D89080718E9732C73F2 /* TerminalConfig.swift */; };
 		DAA8ECCB0288FD778CA430DD /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA87F2112E9FD1A9C106D8F2 /* SidebarView.swift */; };
 		DBFD98B2DDBABADA6AA755D7 /* TerminalApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B2F8E9E8CAEFBB81287640 /* TerminalApp.swift */; };
@@ -84,6 +93,7 @@
 		01AD6AF9F8A70A7E83B56C8C /* QuickTerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickTerminalPane.swift; sourceTree = "<group>"; };
 		0B8A3CDE542974BFD639F6F0 /* CommandRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandRegistry.swift; sourceTree = "<group>"; };
 		0E054D89080718E9732C73F2 /* TerminalConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalConfig.swift; sourceTree = "<group>"; };
+		0E385EC194464E8BF67BE47B /* SplitPaneViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitPaneViewTests.swift; sourceTree = "<group>"; };
 		1055D889FA5B87C7B010166B /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		185BCA9A77D1E03020788D4D /* PreferencesComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesComponents.swift; sourceTree = "<group>"; };
 		1B08540536C434953689D04D /* SessionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStateTests.swift; sourceTree = "<group>"; };
@@ -100,9 +110,12 @@
 		469D41729D62F6520EB09E3B /* SmartPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPanelView.swift; sourceTree = "<group>"; };
 		4FD22E965C6F1A921DC3AFFA /* BellithSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellithSettingsTests.swift; sourceTree = "<group>"; };
 		52E9612F02A1A65DFA8CA240 /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
+		64B019E37CE2B850357E2B7E /* TerminalSurfaceViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceViewTests.swift; sourceTree = "<group>"; };
+		693A40251EB6453D78EFD8E9 /* TerminalTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabModel.swift; sourceTree = "<group>"; };
 		69849D6EC718E0BFF019C9D8 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		6A3BDD2B74A3A4A8B0869659 /* ProcessTreePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessTreePanel.swift; sourceTree = "<group>"; };
 		6C6683BF4D86DE5BB7318C3C /* AboutPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutPane.swift; sourceTree = "<group>"; };
+		707A2AF28DE5D2F8EA639BFB /* TerminalSessionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionCoordinator.swift; sourceTree = "<group>"; };
 		72367912169712669D03FD67 /* TerminalContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalContainerView.swift; sourceTree = "<group>"; };
 		772785F1920803E52A7235C8 /* TerminalProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalProfile.swift; sourceTree = "<group>"; };
 		7AF3EFCA4440E50031AF178C /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -120,6 +133,7 @@
 		90AD21D2101DAB69E92DFB59 /* SessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionState.swift; sourceTree = "<group>"; };
 		92B2F8E9E8CAEFBB81287640 /* TerminalApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalApp.swift; sourceTree = "<group>"; };
 		973180A10E7387D33EBEA8DC /* TerminalWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindow.swift; sourceTree = "<group>"; };
+		97A4045AB00706CFEF094251 /* TerminalContainerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalContainerViewTests.swift; sourceTree = "<group>"; };
 		99AC775F3A6A91CF3FE4CDAB /* SSHProfileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHProfileStoreTests.swift; sourceTree = "<group>"; };
 		9C5308F1710991278921B4D4 /* BellithTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BellithTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C964FC62608F8FA41EE01B5 /* QuickTerminalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickTerminalController.swift; sourceTree = "<group>"; };
@@ -128,8 +142,10 @@
 		A33E81DDDC25CA709CD563AE /* SidebarPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPane.swift; sourceTree = "<group>"; };
 		A9591082C7912641248227C8 /* SSHSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHSessionDetector.swift; sourceTree = "<group>"; };
 		A97FAFCF93CCB562713620EE /* BellithFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellithFont.swift; sourceTree = "<group>"; };
+		AC203E445CE586B521D8FC29 /* GitRepositoryInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryInfoTests.swift; sourceTree = "<group>"; };
 		B8917D92D4F8962901183EEA /* ThemeGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeGridView.swift; sourceTree = "<group>"; };
 		C2EA413DA31A6997580EEAF8 /* SSHSessionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHSessionDetectorTests.swift; sourceTree = "<group>"; };
+		C6E1C3DB1ADB2A4903FA2FF2 /* TerminalRuntimeInfoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRuntimeInfoService.swift; sourceTree = "<group>"; };
 		CB50294EC30FB94671823CFA /* SplitPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitPaneView.swift; sourceTree = "<group>"; };
 		CD0B5E50A6BE76A1D3EDFE6D /* EnvironmentPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentPanel.swift; sourceTree = "<group>"; };
 		D1A6320778E024E8ABCDF2A6 /* SSHLaunchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHLaunchBuilder.swift; sourceTree = "<group>"; };
@@ -138,11 +154,13 @@
 		D7F6C0E62F0D6DFD08E3A8E5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DB0C524BC98C2F0D18E7B327 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		DDFFF00A8FCA7C5D765650BD /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
+		E0E3FC50C1923C38393AB64D /* TerminalOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalOverlayController.swift; sourceTree = "<group>"; };
 		E89FDA87579791818D3A6718 /* TerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPane.swift; sourceTree = "<group>"; };
 		EA87F2112E9FD1A9C106D8F2 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		EC69484808B270DA784451B1 /* SearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarView.swift; sourceTree = "<group>"; };
 		F00EF9188ECCF6928DD41F54 /* StatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarView.swift; sourceTree = "<group>"; };
 		F2088BFA03DDDC079DE5DB8C /* HyperlinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperlinkRouter.swift; sourceTree = "<group>"; };
+		F9994A85D37354E2BFF60705 /* CommandPaletteViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteViewTests.swift; sourceTree = "<group>"; };
 		FC5966D19E6F059737E8B875 /* TerminalContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalContext.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -195,14 +213,19 @@
 			isa = PBXGroup;
 			children = (
 				4FD22E965C6F1A921DC3AFFA /* BellithSettingsTests.swift */,
+				F9994A85D37354E2BFF60705 /* CommandPaletteViewTests.swift */,
+				AC203E445CE586B521D8FC29 /* GitRepositoryInfoTests.swift */,
 				7CDC1927EB617093208667D9 /* HyperlinkRouterTests.swift */,
 				9CB945FE301FBB1B34329681 /* KeyShortcutTests.swift */,
 				8932FC29FCA31DEBC5C25A11 /* ProcessMonitorTests.swift */,
 				1B08540536C434953689D04D /* SessionStateTests.swift */,
+				0E385EC194464E8BF67BE47B /* SplitPaneViewTests.swift */,
 				2647B775021A2DA7887219B7 /* SSHLaunchBuilderTests.swift */,
 				99AC775F3A6A91CF3FE4CDAB /* SSHProfileStoreTests.swift */,
 				C2EA413DA31A6997580EEAF8 /* SSHSessionDetectorTests.swift */,
 				254770B950E6ED2A7FF2ED56 /* TerminalConfigTests.swift */,
+				97A4045AB00706CFEF094251 /* TerminalContainerViewTests.swift */,
+				64B019E37CE2B850357E2B7E /* TerminalSurfaceViewTests.swift */,
 				1055D889FA5B87C7B010166B /* ThemeTests.swift */,
 			);
 			path = BellithTests;
@@ -231,7 +254,9 @@
 				F00EF9188ECCF6928DD41F54 /* StatusBarView.swift */,
 				69849D6EC718E0BFF019C9D8 /* TabBarView.swift */,
 				72367912169712669D03FD67 /* TerminalContainerView.swift */,
+				E0E3FC50C1923C38393AB64D /* TerminalOverlayController.swift */,
 				41878447E775AEA363F6EF96 /* TerminalSurfaceView.swift */,
+				693A40251EB6453D78EFD8E9 /* TerminalTabModel.swift */,
 				973180A10E7387D33EBEA8DC /* TerminalWindow.swift */,
 				21183D4A7A9CA0A0013ED67A /* Theme.swift */,
 				8C5C94B09019221ED3984C56 /* TitleBarView.swift */,
@@ -304,6 +329,8 @@
 				D1A6320778E024E8ABCDF2A6 /* SSHLaunchBuilder.swift */,
 				879EFDEE63113B30DD38B6EA /* SSHProfileStore.swift */,
 				A9591082C7912641248227C8 /* SSHSessionDetector.swift */,
+				C6E1C3DB1ADB2A4903FA2FF2 /* TerminalRuntimeInfoService.swift */,
+				707A2AF28DE5D2F8EA639BFB /* TerminalSessionCoordinator.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -433,6 +460,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				84920B35B7A5167C2AAE9985 /* BellithSettingsTests.swift in Sources */,
+				D976C2EC92ED3D33ECCB9882 /* CommandPaletteViewTests.swift in Sources */,
+				462CADCA785D176937B5F445 /* GitRepositoryInfoTests.swift in Sources */,
 				5863C9295DF764ABD02BC958 /* HyperlinkRouterTests.swift in Sources */,
 				1FE6195879EE4D4D65B24CC1 /* KeyShortcutTests.swift in Sources */,
 				B80E5D2747AB50B714189BC4 /* ProcessMonitorTests.swift in Sources */,
@@ -440,7 +469,10 @@
 				3F067DBCA20A52FB30980DA2 /* SSHProfileStoreTests.swift in Sources */,
 				D8094FD20E0D00F2DB1112D7 /* SSHSessionDetectorTests.swift in Sources */,
 				2D7878CD0D5FB019A68AAA07 /* SessionStateTests.swift in Sources */,
+				8F9C4F38ABE6542683C89C38 /* SplitPaneViewTests.swift in Sources */,
 				0331E3E2063625C041EBDC40 /* TerminalConfigTests.swift in Sources */,
+				27ADA01BC2482B15DEF1FEA8 /* TerminalContainerViewTests.swift in Sources */,
+				02C8AD21D19DCE280556463E /* TerminalSurfaceViewTests.swift in Sources */,
 				8229F53686989E6007E9C7E9 /* ThemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -492,9 +524,13 @@
 				D9B06ED212407C4E58B58CE2 /* TerminalConfig.swift in Sources */,
 				F0688F637632B59A01825393 /* TerminalContainerView.swift in Sources */,
 				37CF1D9BB62D1BB55D63B0D0 /* TerminalContext.swift in Sources */,
+				03D3A8DFD8754842670312F9 /* TerminalOverlayController.swift in Sources */,
 				459FB063C7F788F4E0E549A5 /* TerminalPane.swift in Sources */,
 				DDDD63014E36721A941C97E4 /* TerminalProfile.swift in Sources */,
+				A381D1C113C9D8039615BCA4 /* TerminalRuntimeInfoService.swift in Sources */,
+				B91C9F9881E0670C71C5A556 /* TerminalSessionCoordinator.swift in Sources */,
 				6D65D2902B34E20D77196A44 /* TerminalSurfaceView.swift in Sources */,
+				BD999453ED311F0651C106D3 /* TerminalTabModel.swift in Sources */,
 				11073F73D52E0F9CEAFB4FB5 /* TerminalWindow.swift in Sources */,
 				7F77B0D9CD2EBB86D801E76B /* Theme.swift in Sources */,
 				807142202720783F0B3D8EA6 /* ThemeGridView.swift in Sources */,

--- a/Bellith/Services/TerminalRuntimeInfoService.swift
+++ b/Bellith/Services/TerminalRuntimeInfoService.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+struct TerminalRuntimeStatus {
+    let foregroundProcess: String?
+    let detectedContext: TerminalContext?
+}
+
+enum TerminalRuntimeInfoService {
+    static func runtimeStatus(for shellPID: pid_t?) -> TerminalRuntimeStatus {
+        guard let shellPID,
+              let tree = ProcessMonitor.processTree(rootPID: shellPID) else {
+            return TerminalRuntimeStatus(foregroundProcess: nil, detectedContext: nil)
+        }
+
+        let shellName = ProcessMonitor.processName(for: shellPID)
+        let foregroundProcess = SSHSessionDetector.foregroundProcess(in: tree, shellPID: shellPID)
+        let foregroundName = foregroundProcess?.name.lowercased() == shellName.lowercased()
+            ? nil
+            : foregroundProcess?.name
+        let detectedContext = SSHSessionDetector.detectedContext(
+            in: tree,
+            shellPID: shellPID,
+            arguments: ProcessMonitor.arguments(for:)
+        )
+
+        return TerminalRuntimeStatus(foregroundProcess: foregroundName, detectedContext: detectedContext)
+    }
+
+    static func gitRepositoryInfo(in directory: String) -> GitRepositoryInfo? {
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = [
+            "-C", directory,
+            "rev-parse",
+            "--abbrev-ref", "HEAD",
+            "--git-dir",
+            "--git-common-dir",
+            "--show-toplevel",
+        ]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let output, !output.isEmpty else { return nil }
+
+            let lines = output.components(separatedBy: .newlines)
+            guard lines.count >= 4 else { return nil }
+
+            let branch = normalizedGitOutput(lines[0])
+            let gitDir = resolvedGitURL(for: lines[1], relativeTo: directory)
+            let commonDir = resolvedGitURL(for: lines[2], relativeTo: directory)
+            let topLevel = resolvedGitURL(for: lines[3], relativeTo: directory)
+            let isWorktree = gitDir.resolvingSymlinksInPath().path != commonDir.resolvingSymlinksInPath().path
+            let worktreeName = isWorktree ? topLevel.lastPathComponent : nil
+            return GitRepositoryInfo(branch: branch, worktreeName: worktreeName, isWorktree: isWorktree)
+        } catch {
+            return nil
+        }
+    }
+
+    private static func resolvedGitURL(for path: String, relativeTo directory: String) -> URL {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("/") {
+            return URL(fileURLWithPath: trimmed).standardizedFileURL
+        }
+        return URL(fileURLWithPath: directory, isDirectory: true)
+            .appendingPathComponent(trimmed)
+            .standardizedFileURL
+    }
+
+    private static func normalizedGitOutput(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Bellith/Services/TerminalSessionCoordinator.swift
+++ b/Bellith/Services/TerminalSessionCoordinator.swift
@@ -1,0 +1,257 @@
+import AppKit
+import Foundation
+import GhosttyKit
+import os
+
+protocol TerminalSessionCoordinatorHost: AnyObject {
+    func makeSurface(tabId: UUID, context: TerminalContext) -> TerminalSurfaceView
+    func addRestoredTabRootView(_ view: NSView)
+    func refreshSmartPanelContexts()
+}
+
+final class TerminalSessionCoordinator {
+    private static let maxSplitDepth = 8
+
+    weak var host: TerminalSessionCoordinatorHost?
+
+    init(host: TerminalSessionCoordinatorHost) {
+        self.host = host
+    }
+
+    func saveSession(from tabs: [TerminalTabEntry], selectedTabIndex: Int) -> SessionState {
+        let tabStates = tabs.compactMap { tab -> SessionState.TabState? in
+            switch tab.content {
+            case .terminal(let root, _, _):
+                let tree = root.serialize { view in
+                    (view as? TerminalSurfaceView)?.currentCwd
+                }
+                let context = tab.persistedContext
+                return SessionState.TabState(
+                    title: tab.title,
+                    splitTree: tree,
+                    terminalContext: context,
+                    sshProfileID: context?.sshProfileID
+                )
+            case .smart(let panel):
+                return SessionState.TabState(title: tab.title, smartPanelID: panel.pluginID)
+            }
+        }
+
+        return SessionState(
+            tabs: tabStates,
+            selectedTabIndex: min(selectedTabIndex, max(tabStates.count - 1, 0))
+        )
+    }
+
+    func sessionState(forTabAt index: Int, in tabs: [TerminalTabEntry]) -> SessionState? {
+        guard index >= 0, index < tabs.count else { return nil }
+        let tab = tabs[index]
+
+        let tabState: SessionState.TabState
+        switch tab.content {
+        case .terminal(let root, _, _):
+            let tree = root.serialize { view in
+                (view as? TerminalSurfaceView)?.currentCwd
+            }
+            let context = tab.persistedContext
+            tabState = SessionState.TabState(
+                title: tab.title,
+                splitTree: tree,
+                terminalContext: context,
+                sshProfileID: context?.sshProfileID
+            )
+        case .smart(let panel):
+            tabState = SessionState.TabState(title: tab.title, smartPanelID: panel.pluginID)
+        }
+
+        return SessionState(tabs: [tabState], selectedTabIndex: 0)
+    }
+
+    func restoreSession(_ state: SessionState) -> [TerminalTabEntry] {
+        guard let host else { return [] }
+
+        var restoredTabs: [TerminalTabEntry] = []
+
+        for tabState in state.tabs {
+            let id = UUID()
+
+            switch tabState.kind {
+            case .terminal:
+                guard let splitTree = tabState.splitTree else { continue }
+                let sshProfile = tabState.sshProfileID.flatMap { SSHProfileStore.shared.profile(id: $0) }
+                let restoredContext: TerminalContext
+                if let sshProfile {
+                    restoredContext = sshProfile.launchContext
+                } else if tabState.sshProfileID != nil {
+                    restoredContext = .local
+                } else {
+                    restoredContext = tabState.terminalContext ?? .local
+                }
+
+                var surfaces: [TerminalSurfaceView] = []
+                let splitRoot = buildSplitTree(
+                    splitTree,
+                    tabId: id,
+                    surfaces: &surfaces,
+                    depth: 0,
+                    context: restoredContext,
+                    restoringSSHProfile: sshProfile,
+                    host: host
+                )
+
+                let validSurfaces = surfaces.filter(\.isReady)
+                guard !validSurfaces.isEmpty else {
+                    Logger.app.warning("Session restore: skipping tab '\(tabState.title)' - no valid surfaces")
+                    splitRoot.removeFromSuperview()
+                    continue
+                }
+
+                var entry = TerminalTabEntry(
+                    id: id,
+                    title: tabState.title,
+                    cwd: nil,
+                    content: .terminal(splitRoot: splitRoot, surfaces: validSurfaces, focusedSurface: validSurfaces.first)
+                )
+                entry.cwd = validSurfaces.first?.currentCwd
+                restoredTabs.append(entry)
+                host.addRestoredTabRootView(splitRoot)
+                splitRoot.isHidden = true
+
+                if let sshProfile {
+                    for surface in validSurfaces {
+                        surface.terminalContext = sshProfile.launchContext
+                        send(command: SSHLaunchBuilder.command(for: sshProfile), to: surface)
+                    }
+                }
+
+            case .smart:
+                guard let pluginID = tabState.smartPanelID,
+                      let panel = SmartPanelView.create(pluginID: pluginID) else { continue }
+
+                let entry = TerminalTabEntry(
+                    id: id,
+                    title: tabState.title,
+                    cwd: nil,
+                    content: .smart(panel: panel)
+                )
+                restoredTabs.append(entry)
+                host.addRestoredTabRootView(panel)
+                panel.isHidden = true
+            }
+        }
+
+        return restoredTabs
+    }
+
+    func restoreWorkingDirectory(_ cwd: String, on surface: TerminalSurfaceView) {
+        sendCdWhenReady(surface: surface, cwd: cwd)
+    }
+
+    func send(command: String, to surface: TerminalSurfaceView) {
+        sendCommandWhenReady(surface: surface, command: command)
+    }
+
+    private func buildSplitTree(
+        _ node: SplitNodeState,
+        tabId: UUID,
+        surfaces: inout [TerminalSurfaceView],
+        depth: Int,
+        context: TerminalContext,
+        restoringSSHProfile: SSHProfile?,
+        host: TerminalSessionCoordinatorHost
+    ) -> SplitPaneView {
+        switch node {
+        case .leaf(let cwd):
+            let surface = host.makeSurface(tabId: tabId, context: context)
+            surface.currentCwd = cwd
+            surfaces.append(surface)
+
+            if restoringSSHProfile == nil, let cwd, !cwd.isEmpty {
+                sendCdWhenReady(surface: surface, cwd: cwd)
+            }
+
+            return SplitPaneView(content: surface)
+
+        case .branch(let orientation, let ratio, let firstNode, let secondNode):
+            guard depth < Self.maxSplitDepth else {
+                Logger.app.warning("Session restore: split depth limit reached, collapsing to leaf")
+                let surface = host.makeSurface(tabId: tabId, context: context)
+                surfaces.append(surface)
+                return SplitPaneView(content: surface)
+            }
+
+            let resolvedOrientation: SplitPaneView.Orientation = orientation == "horizontal" ? .horizontal : .vertical
+            let firstChild = buildSplitTree(
+                firstNode,
+                tabId: tabId,
+                surfaces: &surfaces,
+                depth: depth + 1,
+                context: context,
+                restoringSSHProfile: restoringSSHProfile,
+                host: host
+            )
+            let secondChild = buildSplitTree(
+                secondNode,
+                tabId: tabId,
+                surfaces: &surfaces,
+                depth: depth + 1,
+                context: context,
+                restoringSSHProfile: restoringSSHProfile,
+                host: host
+            )
+
+            return SplitPaneView.makeBranch(
+                orientation: resolvedOrientation,
+                ratio: CGFloat(ratio),
+                first: firstChild,
+                second: secondChild
+            )
+        }
+    }
+
+    private func sendCdWhenReady(surface: TerminalSurfaceView, cwd: String, attempt: Int = 0) {
+        let maxAttempts = 5
+        let delay = 0.05 * pow(2.0, Double(attempt))
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, weak surface] in
+            guard let surface, let surf = surface.surface else { return }
+
+            if let currentCwd = surface.currentCwd {
+                guard currentCwd != cwd else { return }
+                let escaped = cwd.replacingOccurrences(of: "'", with: "'\\''")
+                let command = " cd '\(escaped)'\n"
+                command.withCString { ptr in
+                    ghostty_surface_text(surf, ptr, UInt(command.utf8.count))
+                }
+                return
+            }
+
+            if attempt >= maxAttempts {
+                let escaped = cwd.replacingOccurrences(of: "'", with: "'\\''")
+                let command = " cd '\(escaped)'\n"
+                command.withCString { ptr in
+                    ghostty_surface_text(surf, ptr, UInt(command.utf8.count))
+                }
+            } else {
+                self?.sendCdWhenReady(surface: surface, cwd: cwd, attempt: attempt + 1)
+            }
+        }
+    }
+
+    private func sendCommandWhenReady(surface: TerminalSurfaceView, command: String, attempt: Int = 0) {
+        let maxAttempts = 5
+        let delay = 0.06 * pow(2.0, Double(attempt))
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, weak surface] in
+            guard let surface, let surf = surface.surface else { return }
+            let input = command + "\n"
+            input.withCString { ptr in
+                ghostty_surface_text(surf, ptr, UInt(input.utf8.count))
+            }
+
+            if attempt < maxAttempts && surface.currentCwd == nil && surface.terminalContext.isRemote {
+                self?.host?.refreshSmartPanelContexts()
+            }
+        }
+    }
+}

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -3,95 +3,20 @@ import GhosttyKit
 import QuartzCore
 import os
 
-struct GitRepositoryInfo: Equatable {
-    let branch: String?
-    let worktreeName: String?
-    let isWorktree: Bool
-}
-
 /// Container that hosts multiple terminal tabs (each with optional split panes),
 /// smart inspector tabs, a sidebar or tab bar, and the command palette.
-final class TerminalContainerView: NSView {
+final class TerminalContainerView: NSView, TerminalOverlayControllerHost, TerminalSessionCoordinatorHost {
     private enum Metrics {
         static let runtimeRefreshInterval: TimeInterval = 1.0
         static let minimumFontSize: Int = 8
         static let maximumFontSize: Int = 36
     }
 
+    typealias TabContent = TerminalTabContent
+    typealias TabKind = TerminalTabKind
+    typealias TabEntry = TerminalTabEntry
+
     private weak var terminalApp: TerminalApp?
-
-    enum TabContent {
-        case terminal(splitRoot: SplitPaneView, surfaces: [TerminalSurfaceView], focusedSurface: TerminalSurfaceView?)
-        case smart(panel: SmartPanelView)
-    }
-
-    enum TabKind: Equatable {
-        case terminal
-        case smart(String)
-    }
-
-    struct TabEntry {
-        let id: UUID
-        var title: String
-        var cwd: String?
-        var content: TabContent
-
-        var kind: TabKind {
-            switch content {
-            case .terminal: return .terminal
-            case .smart(let panel): return .smart(panel.pluginID)
-            }
-        }
-
-        var splitRoot: SplitPaneView? {
-            if case .terminal(let root, _, _) = content { return root }
-            return nil
-        }
-
-        var surfaces: [TerminalSurfaceView] {
-            if case .terminal(_, let surfaces, _) = content { return surfaces }
-            return []
-        }
-
-        var focusedSurface: TerminalSurfaceView? {
-            get {
-                if case .terminal(_, _, let focused) = content { return focused }
-                return nil
-            }
-            set {
-                if case .terminal(let root, let surfaces, _) = content {
-                    content = .terminal(splitRoot: root, surfaces: surfaces, focusedSurface: newValue)
-                }
-            }
-        }
-
-        var rootView: NSView {
-            switch content {
-            case .terminal(let root, _, _): return root
-            case .smart(let panel): return panel
-            }
-        }
-
-        var isTerminal: Bool {
-            if case .terminal = content { return true }
-            return false
-        }
-
-        mutating func addSurface(_ surface: TerminalSurfaceView) {
-            if case .terminal(let root, var surfaces, _) = content {
-                surfaces.append(surface)
-                content = .terminal(splitRoot: root, surfaces: surfaces, focusedSurface: surface)
-            }
-        }
-
-        mutating func removeSurface(_ surface: TerminalSurfaceView) {
-            if case .terminal(let root, var surfaces, let focused) = content {
-                surfaces.removeAll { $0 === surface }
-                let newFocus = (focused === surface) ? surfaces.last : focused
-                content = .terminal(splitRoot: root, surfaces: surfaces, focusedSurface: newFocus)
-            }
-        }
-    }
 
     private var tabs: [TabEntry] = []
     private(set) var selectedTabIndex: Int = 0
@@ -99,11 +24,14 @@ final class TerminalContainerView: NSView {
     let tabBar = TabBarView()
     let statusBar = StatusBarView()
     let titleBar = TitleBarView()
-    private var commandPalette: CommandPaletteView?
-    private var searchBar: SearchBarView?
+    private lazy var overlayController = TerminalOverlayController(host: self)
+    private lazy var sessionCoordinator = TerminalSessionCoordinator(host: self)
 
-    private(set) var isPaletteVisible = false
-    private var isSearchVisible = false
+    var overlayContainerView: NSView { self }
+    var overlayWindow: NSWindow? { window }
+    var activeSurfaceForOverlay: TerminalSurfaceView? { activeSurface }
+    var isPaletteVisible: Bool { overlayController.isPaletteVisible }
+    private var overlayReferenceView: NSView? { overlayController.presentedOverlayView }
     private var isClosingTab = false
     private var isClosingPane = false
     private var edgeTrackingArea: NSTrackingArea?
@@ -425,6 +353,10 @@ final class TerminalContainerView: NSView {
 
     static func shouldPollRuntimeStatus(windowIsVisible: Bool, isKeyWindow: Bool) -> Bool {
         windowIsVisible && isKeyWindow
+    }
+
+    static func gitRepositoryInfo(in directory: String) -> GitRepositoryInfo? {
+        TerminalRuntimeInfoService.gitRepositoryInfo(in: directory)
     }
 
     private func updateRuntimeStatusObservers() {
@@ -767,7 +699,7 @@ final class TerminalContainerView: NSView {
 
         // Track for reopen
         if entry.isTerminal {
-            recentlyClosedTabs.append((title: entry.title, cwd: entry.cwd, context: persistedContext(for: entry)))
+            recentlyClosedTabs.append((title: entry.title, cwd: entry.cwd, context: entry.persistedContext))
             if recentlyClosedTabs.count > Self.maxRecentlyClosed {
                 recentlyClosedTabs.removeFirst()
             }
@@ -879,7 +811,7 @@ final class TerminalContainerView: NSView {
             window?.makeFirstResponder(focusSurface)
             updateFocusIndicator()
             focusSurface?.refreshReportedSize()
-            let context = focusSurface?.displayContext ?? visibleContext(for: entry)
+            let context = focusSurface?.displayContext ?? entry.visibleContext
             titleBar.updateContext(context)
             statusBar.updateContext(context)
             titleBar.updatePath(entry.cwd)
@@ -958,8 +890,8 @@ final class TerminalContainerView: NSView {
         let pid = findShellPID()
         let activeSurface = activeSurface
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let gitInfo = Self.gitRepositoryInfo(in: cwd)
-            let runtimeStatus = Self.runtimeStatus(for: pid)
+            let gitInfo = TerminalRuntimeInfoService.gitRepositoryInfo(in: cwd)
+            let runtimeStatus = TerminalRuntimeInfoService.runtimeStatus(for: pid)
 
             DispatchQueue.main.async {
                 guard let self,
@@ -990,7 +922,7 @@ final class TerminalContainerView: NSView {
         let pid = findShellPID()
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self, weak surface] in
-            let runtimeStatus = Self.runtimeStatus(for: pid)
+            let runtimeStatus = TerminalRuntimeInfoService.runtimeStatus(for: pid)
 
             DispatchQueue.main.async {
                 guard let self, let surface else { return }
@@ -1008,100 +940,6 @@ final class TerminalContainerView: NSView {
         }
     }
 
-    private struct RuntimeStatus {
-        let foregroundProcess: String?
-        let detectedContext: TerminalContext?
-    }
-
-    private static func runtimeStatus(for shellPID: pid_t?) -> RuntimeStatus {
-        guard let shellPID,
-              let tree = ProcessMonitor.processTree(rootPID: shellPID) else {
-            return RuntimeStatus(foregroundProcess: nil, detectedContext: nil)
-        }
-
-        let shellName = ProcessMonitor.processName(for: shellPID)
-        let foregroundProcess = SSHSessionDetector.foregroundProcess(in: tree, shellPID: shellPID)
-        let foregroundName = foregroundProcess?.name.lowercased() == shellName.lowercased()
-            ? nil
-            : foregroundProcess?.name
-        let detectedContext = SSHSessionDetector.detectedContext(
-            in: tree,
-            shellPID: shellPID,
-            arguments: ProcessMonitor.arguments(for:)
-        )
-
-        return RuntimeStatus(foregroundProcess: foregroundName, detectedContext: detectedContext)
-    }
-
-    static func gitRepositoryInfo(in directory: String) -> GitRepositoryInfo? {
-        let pipe = Pipe()
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-        process.arguments = [
-            "-C", directory,
-            "rev-parse",
-            "--abbrev-ref", "HEAD",
-            "--git-dir",
-            "--git-common-dir",
-            "--show-toplevel",
-        ]
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return nil }
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            guard let output, !output.isEmpty else { return nil }
-
-            let lines = output.components(separatedBy: .newlines)
-            guard lines.count >= 4 else { return nil }
-
-            let branch = normalizedGitOutput(lines[0])
-            let gitDir = resolvedGitURL(for: lines[1], relativeTo: directory)
-            let commonDir = resolvedGitURL(for: lines[2], relativeTo: directory)
-            let topLevel = resolvedGitURL(for: lines[3], relativeTo: directory)
-            let isWorktree = gitDir.resolvingSymlinksInPath().path != commonDir.resolvingSymlinksInPath().path
-            let worktreeName = isWorktree ? topLevel.lastPathComponent : nil
-            return GitRepositoryInfo(branch: branch, worktreeName: worktreeName, isWorktree: isWorktree)
-        } catch { return nil }
-    }
-
-    private static func resolvedGitURL(for path: String, relativeTo directory: String) -> URL {
-        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("/") {
-            return URL(fileURLWithPath: trimmed).standardizedFileURL
-        }
-        return URL(fileURLWithPath: directory, isDirectory: true)
-            .appendingPathComponent(trimmed)
-            .standardizedFileURL
-    }
-
-    private static func normalizedGitOutput(_ text: String) -> String? {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
-    private func persistedContext(for entry: TabEntry) -> TerminalContext? {
-        switch entry.content {
-        case .terminal(_, let surfaces, let focusedSurface):
-            return focusedSurface?.terminalContext ?? surfaces.first?.terminalContext ?? .local
-        case .smart:
-            return nil
-        }
-    }
-
-    private func visibleContext(for entry: TabEntry) -> TerminalContext? {
-        switch entry.content {
-        case .terminal(_, let surfaces, let focusedSurface):
-            return focusedSurface?.displayContext ?? surfaces.first?.displayContext ?? .local
-        case .smart:
-            return nil
-        }
-    }
-
     func connectSSHProfile(id: UUID) {
         guard let profile = SSHProfileStore.shared.profile(id: id) else {
             PreferencesWindowController.shared.showWindow(selecting: "ssh")
@@ -1110,7 +948,7 @@ final class TerminalContainerView: NSView {
 
         let context = profile.launchContext
         guard let surface = createTab(titleOverride: profile.displayName, context: context) else { return }
-        sendCommandWhenReady(surface: surface, command: SSHLaunchBuilder.command(for: profile))
+        sessionCoordinator.send(command: SSHLaunchBuilder.command(for: profile), to: surface)
     }
 
     var activeCwd: String {
@@ -1266,7 +1104,7 @@ final class TerminalContainerView: NSView {
 
             // Zoom in: cross-fade from split tree to zoomed surface
             entry.splitRoot?.isHidden = true
-            addSubview(focused, positioned: .below, relativeTo: commandPalette ?? searchBar)
+            addSubview(focused, positioned: .below, relativeTo: overlayReferenceView)
             focused.frame = contentRect
             focused.alphaValue = 0
             NSAnimationContext.runAnimationGroup { ctx in
@@ -1390,11 +1228,11 @@ final class TerminalContainerView: NSView {
     @objc private func contextMenuDuplicateTab(_ sender: NSMenuItem) {
         guard let index = sender.representedObject as? Int, index < tabs.count else { return }
         let cwd = tabs[index].cwd
-        let context = persistedContext(for: tabs[index])
+        let context = tabs[index].persistedContext
         if let sshProfileID = context?.sshProfileID, SSHProfileStore.shared.profile(id: sshProfileID) != nil {
             connectSSHProfile(id: sshProfileID)
         } else if let surface = createTab(titleOverride: tabs[index].title, context: context ?? .local), let cwd, !cwd.isEmpty {
-            sendCdWhenReady(surface: surface, cwd: cwd)
+            sessionCoordinator.restoreWorkingDirectory(cwd, on: surface)
         }
     }
 
@@ -1412,7 +1250,7 @@ final class TerminalContainerView: NSView {
         if let sshProfileID = last.context?.sshProfileID, SSHProfileStore.shared.profile(id: sshProfileID) != nil {
             connectSSHProfile(id: sshProfileID)
         } else if let surface = createTab(titleOverride: last.title, context: last.context ?? .local), let cwd = last.cwd, !cwd.isEmpty {
-            sendCdWhenReady(surface: surface, cwd: cwd)
+            sessionCoordinator.restoreWorkingDirectory(cwd, on: surface)
         }
     }
 
@@ -1493,6 +1331,10 @@ final class TerminalContainerView: NSView {
             guard case .smart(let panel) = tab.content else { continue }
             panel.shellPID = shellPID
         }
+    }
+
+    func refreshSmartPanelContexts() {
+        updateSmartPanelContexts()
     }
 
     /// Find the shell PID for the most relevant terminal context by looking up the
@@ -1785,8 +1627,7 @@ final class TerminalContainerView: NSView {
         tabBar.refreshTheme()
         statusBar.refreshTheme()
         titleBar.refreshTheme()
-        commandPalette?.refreshTheme()
-        searchBar?.refreshTheme()
+        overlayController.refreshTheme()
         for tab in tabs {
             tab.splitRoot?.refreshTheme()
             applyChrome(to: tab.rootView)
@@ -1837,28 +1678,18 @@ final class TerminalContainerView: NSView {
     // MARK: - Command Palette
 
     func toggleCommandPalette() {
-        if isPaletteVisible { hideCommandPalette() } else { showCommandPalette() }
+        overlayController.toggleCommandPalette()
     }
 
     func showCommandPalette() {
-        guard !isPaletteVisible else { return }
-        isPaletteVisible = true
-
-        let palette = CommandPaletteView()
-        palette.onSubmit = { [weak self] text in self?.handleCommand(text) }
-        palette.onDismiss = { [weak self] in
-            self?.isPaletteVisible = false
-            self?.commandPalette = nil
-            self?.window?.makeFirstResponder(self?.activeSurface)
-        }
-        commandPalette = palette
-        palette.show(in: self)
-        (window as? TerminalWindow)?.showTrafficLights()
+        overlayController.showCommandPalette()
     }
 
-    func hideCommandPalette() { commandPalette?.hide() }
+    func hideCommandPalette() {
+        overlayController.hideCommandPalette()
+    }
 
-    private func handleCommand(_ text: String) {
+    func performCommandPaletteCommand(_ text: String) {
         let cmd = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if let command = CommandRegistry.shared.command(matching: cmd) {
@@ -1894,68 +1725,19 @@ final class TerminalContainerView: NSView {
     // MARK: - Search
 
     func showSearch(initialNeedle: String? = nil) {
-        guard !isSearchVisible else { return }
-        isSearchVisible = true
-
-        let bar = SearchBarView()
-        bar.onSearch = { [weak self] query in self?.performSearch(query) }
-        bar.onNext = { [weak self] in self?.searchNext() }
-        bar.onPrev = { [weak self] in self?.searchPrev() }
-        bar.onDismiss = { [weak self] in
-            self?.isSearchVisible = false
-            self?.searchBar = nil
-            if let surface = self?.activeSurface?.surface {
-                let action = "close_surface_search"
-                action.withCString { ptr in
-                    _ = ghostty_surface_binding_action(surface, ptr, UInt(action.utf8.count))
-                }
-            }
-            self?.window?.makeFirstResponder(self?.activeSurface)
-        }
-
-        searchBar = bar
-        if let needle = initialNeedle { bar.setQuery(needle) }
-        bar.show(in: self)
+        overlayController.showSearch(initialNeedle: initialNeedle)
     }
 
     func hideSearch() {
-        guard isSearchVisible else { return }
-        searchBar?.hide()
+        overlayController.hideSearch()
     }
 
-    private var searchTotal: Int = 0
-
     func updateSearchTotal(_ total: Int) {
-        searchTotal = total
-        searchBar?.updateCount(selected: 0, total: total)
+        overlayController.updateSearchTotal(total)
     }
 
     func updateSearchSelected(_ selected: Int) {
-        searchBar?.updateCount(selected: selected, total: searchTotal)
-    }
-
-    private func performSearch(_ query: String) {
-        guard let surface = activeSurface?.surface else { return }
-        let action = "search_forward:\(query)"
-        _ = action.withCString { ptr in
-            ghostty_surface_binding_action(surface, ptr, UInt(action.utf8.count))
-        }
-    }
-
-    private func searchNext() {
-        guard let surface = activeSurface?.surface else { return }
-        let action = "search_forward"
-        _ = action.withCString { ptr in
-            ghostty_surface_binding_action(surface, ptr, UInt(action.utf8.count))
-        }
-    }
-
-    private func searchPrev() {
-        guard let surface = activeSurface?.surface else { return }
-        let action = "search_backward"
-        _ = action.withCString { ptr in
-            ghostty_surface_binding_action(surface, ptr, UInt(action.utf8.count))
-        }
+        overlayController.updateSearchSelected(selected)
     }
 
     // MARK: - Copy / Paste
@@ -2036,123 +1818,21 @@ final class TerminalContainerView: NSView {
     // MARK: - Session Save / Restore
 
     func saveSession() -> SessionState {
-        let tabStates = tabs.compactMap { tab -> SessionState.TabState? in
-            switch tab.content {
-            case .terminal(let root, _, _):
-                let tree = root.serialize { view in
-                    (view as? TerminalSurfaceView)?.currentCwd
-                }
-                let context = persistedContext(for: tab)
-                return SessionState.TabState(
-                    title: tab.title,
-                    splitTree: tree,
-                    terminalContext: context,
-                    sshProfileID: context?.sshProfileID
-                )
-            case .smart(let panel):
-                return SessionState.TabState(title: tab.title, smartPanelID: panel.pluginID)
-            }
-        }
-        return SessionState(tabs: tabStates, selectedTabIndex: min(selectedTabIndex, max(tabStates.count - 1, 0)))
+        sessionCoordinator.saveSession(from: tabs, selectedTabIndex: selectedTabIndex)
     }
 
     func sessionState(forTabAt index: Int) -> SessionState? {
-        guard index >= 0, index < tabs.count else { return nil }
-        let tab = tabs[index]
-
-        let tabState: SessionState.TabState
-        switch tab.content {
-        case .terminal(let root, _, _):
-            let tree = root.serialize { view in
-                (view as? TerminalSurfaceView)?.currentCwd
-            }
-            let context = persistedContext(for: tab)
-            tabState = SessionState.TabState(
-                title: tab.title,
-                splitTree: tree,
-                terminalContext: context,
-                sshProfileID: context?.sshProfileID
-            )
-        case .smart(let panel):
-            tabState = SessionState.TabState(title: tab.title, smartPanelID: panel.pluginID)
-        }
-
-        return SessionState(tabs: [tabState], selectedTabIndex: 0)
+        sessionCoordinator.sessionState(forTabAt: index, in: tabs)
     }
 
     func restoreSession(_ state: SessionState) {
-        guard let terminalApp else { return }
+        guard terminalApp != nil else { return }
 
         for tab in tabs {
             tab.rootView.removeFromSuperview()
         }
         tabs.removeAll()
-
-        for tabState in state.tabs {
-            let id = UUID()
-
-            switch tabState.kind {
-            case .terminal:
-                guard let splitTree = tabState.splitTree else { continue }
-                let sshProfile = tabState.sshProfileID.flatMap { SSHProfileStore.shared.profile(id: $0) }
-                let restoredContext: TerminalContext
-                if let sshProfile {
-                    restoredContext = sshProfile.launchContext
-                } else if tabState.sshProfileID != nil {
-                    restoredContext = .local
-                } else {
-                    restoredContext = tabState.terminalContext ?? .local
-                }
-
-                var surfaces: [TerminalSurfaceView] = []
-                let splitRoot = buildSplitTree(
-                    splitTree,
-                    tabId: id,
-                    app: terminalApp,
-                    surfaces: &surfaces,
-                    depth: 0,
-                    context: restoredContext,
-                    restoringSSHProfile: sshProfile
-                )
-
-                // Validate: at least one surface must have initialized successfully
-                let validSurfaces = surfaces.filter { $0.isReady }
-                guard !validSurfaces.isEmpty else {
-                    Logger.app.warning("Session restore: skipping tab '\(tabState.title)' — no valid surfaces")
-                    splitRoot.removeFromSuperview()
-                    continue
-                }
-
-                var entry = TabEntry(
-                    id: id, title: tabState.title, cwd: nil,
-                    content: .terminal(splitRoot: splitRoot, surfaces: validSurfaces, focusedSurface: validSurfaces.first)
-                )
-                if let firstCwd = validSurfaces.first?.currentCwd {
-                    entry.cwd = firstCwd
-                }
-                tabs.append(entry)
-                addSubview(splitRoot, positioned: .below, relativeTo: sidebar)
-                splitRoot.isHidden = true
-
-                if let sshProfile {
-                    for surface in validSurfaces {
-                        surface.terminalContext = sshProfile.launchContext
-                        sendCommandWhenReady(surface: surface, command: SSHLaunchBuilder.command(for: sshProfile))
-                    }
-                }
-
-            case .smart:
-                guard let pluginID = tabState.smartPanelID,
-                      let panel = SmartPanelView.create(pluginID: pluginID) else { continue }
-                let entry = TabEntry(
-                    id: id, title: tabState.title, cwd: nil,
-                    content: .smart(panel: panel)
-                )
-                tabs.append(entry)
-                addSubview(panel, positioned: .below, relativeTo: sidebar)
-                panel.isHidden = true
-            }
-        }
+        tabs = sessionCoordinator.restoreSession(state)
 
         if tabs.isEmpty {
             createTab()
@@ -2163,69 +1843,20 @@ final class TerminalContainerView: NSView {
         refreshTabUI()
     }
 
-    private static let maxSplitDepth = 8
-
-    private func buildSplitTree(
-        _ node: SplitNodeState,
-        tabId: UUID,
-        app: TerminalApp,
-        surfaces: inout [TerminalSurfaceView],
-        depth: Int,
-        context: TerminalContext,
-        restoringSSHProfile: SSHProfile?
-    ) -> SplitPaneView {
-        switch node {
-        case .leaf(let cwd):
-            let surface = makeSurface(tabId: tabId, app: app, context: context)
-            surface.currentCwd = cwd
-            surfaces.append(surface)
-
-            if restoringSSHProfile == nil, let cwd, !cwd.isEmpty {
-                sendCdWhenReady(surface: surface, cwd: cwd)
-            }
-
-            return SplitPaneView(content: surface)
-
-        case .branch(let orientation, let ratio, let firstNode, let secondNode):
-            // Depth limit to prevent pathological session data from stack overflow
-            guard depth < Self.maxSplitDepth else {
-                Logger.app.warning("Session restore: split depth limit reached, collapsing to leaf")
-                let surface = makeSurface(tabId: tabId, app: app, context: context)
-                surfaces.append(surface)
-                return SplitPaneView(content: surface)
-            }
-
-            let ori: SplitPaneView.Orientation = orientation == "horizontal" ? .horizontal : .vertical
-            let firstChild = buildSplitTree(
-                firstNode,
-                tabId: tabId,
-                app: app,
-                surfaces: &surfaces,
-                depth: depth + 1,
-                context: context,
-                restoringSSHProfile: restoringSSHProfile
-            )
-            let secondChild = buildSplitTree(
-                secondNode,
-                tabId: tabId,
-                app: app,
-                surfaces: &surfaces,
-                depth: depth + 1,
-                context: context,
-                restoringSSHProfile: restoringSSHProfile
-            )
-            return SplitPaneView.makeBranch(
-                orientation: ori,
-                ratio: CGFloat(ratio),
-                first: firstChild,
-                second: secondChild
-            )
-        }
-    }
-
     // MARK: - Surface Factory
 
     /// Centralized surface creation — wires up all callbacks (onClose, onTextInserted).
+    func makeSurface(tabId: UUID, context: TerminalContext) -> TerminalSurfaceView {
+        guard let terminalApp else {
+            preconditionFailure("Terminal app must exist before creating a surface")
+        }
+        return makeSurface(tabId: tabId, app: terminalApp, context: context)
+    }
+
+    func addRestoredTabRootView(_ view: NSView) {
+        addSubview(view, positioned: .below, relativeTo: sidebar)
+    }
+
     private func makeSurface(tabId: UUID, app: TerminalApp, context: TerminalContext) -> TerminalSurfaceView {
         let surface = TerminalSurfaceView(app: app)
         surface.terminalContext = context
@@ -2293,57 +1924,7 @@ final class TerminalContainerView: NSView {
             updateSmartPanelContexts()
             refreshTabUI()
         }
-        sendCdWhenReady(surface: surface, cwd: cwd)
-    }
-
-    // MARK: - Session Restore Helpers
-
-    /// Send a `cd` command to a surface once the shell is ready, with exponential backoff.
-    private func sendCdWhenReady(surface: TerminalSurfaceView, cwd: String, attempt: Int = 0) {
-        let maxAttempts = 5
-        let delay = 0.05 * pow(2.0, Double(attempt))
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, weak surface] in
-            guard let surface, let surf = surface.surface else { return }
-
-            // If the shell has reported its cwd already, only send `cd` when needed.
-            if let currentCwd = surface.currentCwd {
-                guard currentCwd != cwd else { return }
-                let escaped = cwd.replacingOccurrences(of: "'", with: "'\\''")
-                let cmd = " cd '\(escaped)'\n"
-                cmd.withCString { ptr in
-                    ghostty_surface_text(surf, ptr, UInt(cmd.utf8.count))
-                }
-                return
-            }
-
-            if attempt >= maxAttempts {
-                let escaped = cwd.replacingOccurrences(of: "'", with: "'\\''")
-                let cmd = " cd '\(escaped)'\n"
-                cmd.withCString { ptr in
-                    ghostty_surface_text(surf, ptr, UInt(cmd.utf8.count))
-                }
-            } else {
-                self?.sendCdWhenReady(surface: surface, cwd: cwd, attempt: attempt + 1)
-            }
-        }
-    }
-
-    private func sendCommandWhenReady(surface: TerminalSurfaceView, command: String, attempt: Int = 0) {
-        let maxAttempts = 5
-        let delay = 0.06 * pow(2.0, Double(attempt))
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, weak surface] in
-            guard let surface, let surf = surface.surface else { return }
-            let input = command + "\n"
-            input.withCString { ptr in
-                ghostty_surface_text(surf, ptr, UInt(input.utf8.count))
-            }
-
-            if attempt < maxAttempts && surface.currentCwd == nil && surface.terminalContext.isRemote {
-                self?.updateSmartPanelContexts()
-            }
-        }
+        sessionCoordinator.restoreWorkingDirectory(cwd, on: surface)
     }
 }
 

--- a/Bellith/Views/TerminalOverlayController.swift
+++ b/Bellith/Views/TerminalOverlayController.swift
@@ -1,0 +1,130 @@
+import AppKit
+import GhosttyKit
+
+protocol TerminalOverlayControllerHost: AnyObject {
+    var overlayContainerView: NSView { get }
+    var overlayWindow: NSWindow? { get }
+    var activeSurfaceForOverlay: TerminalSurfaceView? { get }
+    func performCommandPaletteCommand(_ text: String)
+}
+
+final class TerminalOverlayController {
+    weak var host: TerminalOverlayControllerHost?
+
+    private(set) var isPaletteVisible = false
+    private var isSearchVisible = false
+    private var searchTotal = 0
+    private var commandPalette: CommandPaletteView?
+    private var searchBar: SearchBarView?
+
+    init(host: TerminalOverlayControllerHost) {
+        self.host = host
+    }
+
+    var presentedOverlayView: NSView? {
+        commandPalette ?? searchBar
+    }
+
+    func refreshTheme() {
+        commandPalette?.refreshTheme()
+        searchBar?.refreshTheme()
+    }
+
+    func toggleCommandPalette() {
+        if isPaletteVisible {
+            hideCommandPalette()
+        } else {
+            showCommandPalette()
+        }
+    }
+
+    func showCommandPalette() {
+        guard !isPaletteVisible, let host else { return }
+        isPaletteVisible = true
+
+        let palette = CommandPaletteView()
+        palette.onSubmit = { [weak self] text in
+            self?.host?.performCommandPaletteCommand(text)
+        }
+        palette.onDismiss = { [weak self] in
+            guard let self else { return }
+            self.isPaletteVisible = false
+            self.commandPalette = nil
+            self.host?.overlayWindow?.makeFirstResponder(self.host?.activeSurfaceForOverlay)
+        }
+
+        commandPalette = palette
+        palette.show(in: host.overlayContainerView)
+        (host.overlayWindow as? TerminalWindow)?.showTrafficLights()
+    }
+
+    func hideCommandPalette() {
+        commandPalette?.hide()
+    }
+
+    func showSearch(initialNeedle: String? = nil) {
+        guard !isSearchVisible, let host else { return }
+        isSearchVisible = true
+
+        let bar = SearchBarView()
+        bar.onSearch = { [weak self] query in
+            self?.performSearch(query)
+        }
+        bar.onNext = { [weak self] in
+            self?.searchNext()
+        }
+        bar.onPrev = { [weak self] in
+            self?.searchPrev()
+        }
+        bar.onDismiss = { [weak self] in
+            guard let self else { return }
+            self.isSearchVisible = false
+            self.searchBar = nil
+            self.closeSurfaceSearch()
+            self.host?.overlayWindow?.makeFirstResponder(self.host?.activeSurfaceForOverlay)
+        }
+
+        searchBar = bar
+        if let needle = initialNeedle {
+            bar.setQuery(needle)
+        }
+        bar.show(in: host.overlayContainerView)
+    }
+
+    func hideSearch() {
+        guard isSearchVisible else { return }
+        searchBar?.hide()
+    }
+
+    func updateSearchTotal(_ total: Int) {
+        searchTotal = total
+        searchBar?.updateCount(selected: 0, total: total)
+    }
+
+    func updateSearchSelected(_ selected: Int) {
+        searchBar?.updateCount(selected: selected, total: searchTotal)
+    }
+
+    private func performSearch(_ query: String) {
+        performSurfaceAction("search_forward:\(query)")
+    }
+
+    private func searchNext() {
+        performSurfaceAction("search_forward")
+    }
+
+    private func searchPrev() {
+        performSurfaceAction("search_backward")
+    }
+
+    private func closeSurfaceSearch() {
+        performSurfaceAction("close_surface_search")
+    }
+
+    private func performSurfaceAction(_ action: String) {
+        guard let surface = host?.activeSurfaceForOverlay?.surface else { return }
+        _ = action.withCString { ptr in
+            ghostty_surface_binding_action(surface, ptr, UInt(action.utf8.count))
+        }
+    }
+}

--- a/Bellith/Views/TerminalTabModel.swift
+++ b/Bellith/Views/TerminalTabModel.swift
@@ -1,0 +1,102 @@
+import AppKit
+
+struct GitRepositoryInfo: Equatable {
+    let branch: String?
+    let worktreeName: String?
+    let isWorktree: Bool
+}
+
+enum TerminalTabContent {
+    case terminal(splitRoot: SplitPaneView, surfaces: [TerminalSurfaceView], focusedSurface: TerminalSurfaceView?)
+    case smart(panel: SmartPanelView)
+}
+
+enum TerminalTabKind: Equatable {
+    case terminal
+    case smart(String)
+}
+
+struct TerminalTabEntry {
+    let id: UUID
+    var title: String
+    var cwd: String?
+    var content: TerminalTabContent
+
+    var kind: TerminalTabKind {
+        switch content {
+        case .terminal:
+            return .terminal
+        case .smart(let panel):
+            return .smart(panel.pluginID)
+        }
+    }
+
+    var splitRoot: SplitPaneView? {
+        if case .terminal(let root, _, _) = content { return root }
+        return nil
+    }
+
+    var surfaces: [TerminalSurfaceView] {
+        if case .terminal(_, let surfaces, _) = content { return surfaces }
+        return []
+    }
+
+    var focusedSurface: TerminalSurfaceView? {
+        get {
+            if case .terminal(_, _, let focused) = content { return focused }
+            return nil
+        }
+        set {
+            if case .terminal(let root, let surfaces, _) = content {
+                content = .terminal(splitRoot: root, surfaces: surfaces, focusedSurface: newValue)
+            }
+        }
+    }
+
+    var rootView: NSView {
+        switch content {
+        case .terminal(let root, _, _):
+            return root
+        case .smart(let panel):
+            return panel
+        }
+    }
+
+    var isTerminal: Bool {
+        if case .terminal = content { return true }
+        return false
+    }
+
+    var persistedContext: TerminalContext? {
+        switch content {
+        case .terminal(_, let surfaces, let focusedSurface):
+            return focusedSurface?.terminalContext ?? surfaces.first?.terminalContext ?? .local
+        case .smart:
+            return nil
+        }
+    }
+
+    var visibleContext: TerminalContext? {
+        switch content {
+        case .terminal(_, let surfaces, let focusedSurface):
+            return focusedSurface?.displayContext ?? surfaces.first?.displayContext ?? .local
+        case .smart:
+            return nil
+        }
+    }
+
+    mutating func addSurface(_ surface: TerminalSurfaceView) {
+        if case .terminal(let root, var surfaces, _) = content {
+            surfaces.append(surface)
+            content = .terminal(splitRoot: root, surfaces: surfaces, focusedSurface: surface)
+        }
+    }
+
+    mutating func removeSurface(_ surface: TerminalSurfaceView) {
+        if case .terminal(let root, var surfaces, let focused) = content {
+            surfaces.removeAll { $0 === surface }
+            let newFocus = (focused === surface) ? surfaces.last : focused
+            content = .terminal(splitRoot: root, surfaces: surfaces, focusedSurface: newFocus)
+        }
+    }
+}

--- a/BellithTests/GitRepositoryInfoTests.swift
+++ b/BellithTests/GitRepositoryInfoTests.swift
@@ -36,7 +36,7 @@ final class GitRepositoryInfoTests: XCTestCase {
     private func runGit(_ arguments: [String], in directory: URL) throws {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-        process.arguments = arguments
+        process.arguments = ["-c", "commit.gpgsign=false"] + arguments
         process.currentDirectoryURL = directory
 
         let outputPipe = Pipe()


### PR DESCRIPTION
## Summary
- extract terminal tab models, runtime status helpers, overlay handling, and session restore/save into dedicated types
- reduce TerminalContainerView responsibility to container orchestration and preserve existing behavior through coordinator-style interfaces
- harden GitRepositoryInfoTests by disabling commit signing in the local git helper for deterministic test runs

## Testing
- xcodebuild -project Bellith.xcodeproj -scheme Bellith -configuration Debug -derivedDataPath /tmp/bellith-derived test

Closes #8