### PR TITLE
feat(terminal): expose inline image protocol toggle

### DIFF
--- a/Bellith/Bridge/TerminalConfig.swift
+++ b/Bellith/Bridge/TerminalConfig.swift
@@ -151,6 +151,9 @@ final class TerminalConfig {
         if !s.shell.isEmpty {
             lines.append("command = \(s.shell)")
         }
+        if !s.inlineImagesEnabled {
+            lines.append("image-storage-limit = 0")
+        }
         lines.append(contentsOf: macOSTerminalCompatibility.keybinds)
 
         do {

--- a/Bellith/Models/BellithSettings.swift
+++ b/Bellith/Models/BellithSettings.swift
@@ -70,6 +70,7 @@ final class BellithSettings {
         ]
         static let boolKeys: Set<String> = [
             "mouseHideWhileTyping", "confirmClose", "restoreSession", "cursorBlink",
+            "inlineImagesEnabled",
             "shellIntegrationEnabled", "shellIntegrationCursor", "shellIntegrationTitle",
             "shellIntegrationPath", "shellIntegrationSSHEnv", "shellIntegrationSSHTerminfo",
             "commandCompletionNotificationsEnabled", "sidebarPinned", "sidebarAutoHide",
@@ -204,6 +205,19 @@ final class BellithSettings {
     var cursorBlink: Bool {
         get { defaults.bool(forKey: "cursorBlink") }
         set { defaults.set(newValue, forKey: "cursorBlink"); notify() }
+    }
+
+    /// Enables Ghostty's inline image protocols (Kitty graphics + Sixel).
+    /// When disabled, Ghostty's image storage limit is forced to 0 so tools
+    /// like `icat`, `chafa`, `timg`, and Sixel emitters skip rendering.
+    var inlineImagesEnabled: Bool {
+        get {
+            if defaults.object(forKey: "inlineImagesEnabled") != nil {
+                return defaults.bool(forKey: "inlineImagesEnabled")
+            }
+            return true
+        }
+        set { defaults.set(newValue, forKey: "inlineImagesEnabled"); notify() }
     }
 
     var shellIntegrationEnabled: Bool {
@@ -879,6 +893,7 @@ final class BellithSettings {
             "fontFamily": fontFamily,
             "fontSize": fontSize,
             "featureFlags": featureFlagsForSettingsFile,
+            "inlineImagesEnabled": inlineImagesEnabled,
             "keybindings": encodedKeybindings,
             "lightThemeName": lightThemeName,
             "mouseHideWhileTyping": mouseHideWhileTyping,

--- a/Bellith/Views/Preferences/TerminalPane.swift
+++ b/Bellith/Views/Preferences/TerminalPane.swift
@@ -75,6 +75,11 @@ final class TerminalPane: NSView {
     private let commandNotificationThresholdUnit = SmallLabel("SECONDS")
     private let shellIntegrationNote = FooterNote("Prompt marks, command timing, and completion notifications require shell integration.")
 
+    private let graphicsCard = SettingsCard(title: "Graphics", subtitle: "Inline image protocols supported by Ghostty")
+    private let inlineImagesLabel = CardRowLabel("Inline Images")
+    private var inlineImagesToggle: PrefToggle!
+    private let inlineImagesNote = FooterNote("Enables Kitty graphics and Sixel so tools like icat, chafa, timg, and gnuplot draw directly in the terminal.")
+
     private let behaviorCard = SettingsCard(title: "Behavior", subtitle: "Session lifecycle, cursor visibility, and terminal modifier keys")
     private let optionKeyLabel = CardRowLabel("Option Key")
     private let optionKeyNote = FooterNote("Left Option sends terminal Alt shortcuts while Right Option continues to type special characters.")
@@ -276,6 +281,14 @@ final class TerminalPane: NSView {
         optionKeyPopup.action = #selector(handleOptionKeyBehaviorChanged)
         TerminalOptionKeyBehavior.allCases.forEach { optionKeyPopup.addItem(withTitle: $0.title) }
 
+        inlineImagesToggle = PrefToggle(isOn: settings.inlineImagesEnabled) { [weak self] value in
+            self?.settings.inlineImagesEnabled = value
+        }
+        content.addSubview(graphicsCard)
+        for view: NSView in [inlineImagesLabel, inlineImagesToggle, inlineImagesNote] {
+            graphicsCard.addSubview(view)
+        }
+
         hideMouseToggle = PrefToggle(isOn: settings.mouseHideWhileTyping) { [weak self] value in self?.settings.mouseHideWhileTyping = value }
         confirmToggle = PrefToggle(isOn: settings.confirmClose) { [weak self] value in self?.settings.confirmClose = value }
         restoreToggle = PrefToggle(isOn: settings.restoreSession) { [weak self] value in self?.settings.restoreSession = value }
@@ -315,6 +328,7 @@ final class TerminalPane: NSView {
         cursorCard.refresh()
         sessionCard.refresh()
         shellIntegrationCard.refresh()
+        graphicsCard.refresh()
         behaviorCard.refresh()
         fontField.updateText(settings.fontFamily)
         sizeValue.stringValue = "\(settings.fontSize)"
@@ -334,6 +348,7 @@ final class TerminalPane: NSView {
         shellIntegrationSSHTerminfoToggle.setOn(settings.shellIntegrationSSHTerminfo)
         commandNotificationsToggle.setOn(settings.commandCompletionNotificationsEnabled)
         commandNotificationThresholdField.setValue(settings.commandCompletionNotificationThreshold)
+        inlineImagesToggle.setOn(settings.inlineImagesEnabled)
         optionKeyPopup.selectItem(at: TerminalOptionKeyBehavior.allCases.firstIndex(of: settings.terminalOptionKeyBehavior) ?? 0)
         hideMouseToggle.setOn(settings.mouseHideWhileTyping)
         confirmToggle.setOn(settings.confirmClose)
@@ -480,6 +495,15 @@ final class TerminalPane: NSView {
         commandNotificationThresholdUnit.frame = NSRect(x: controlX + 106, y: ir7 + 12, width: 64, height: 12)
         shellIntegrationNote.frame = NSRect(x: PreferencesLayout.cardPad, y: PreferencesLayout.cardPad - 2, width: innerW, height: 14)
         y += shellIntegrationCardHeight + PreferencesLayout.sectionGap
+
+        let graphicsLabelW = PreferencesLayout.labelWidth(toTrailingToggleIn: cardW)
+        let graphicsCardHeight = graphicsCard.headerHeight + PreferencesLayout.rowH + 14 + PreferencesLayout.rowGap + PreferencesLayout.cardPad
+        graphicsCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardW, height: graphicsCardHeight)
+        let gr0 = graphicsCardHeight - graphicsCard.headerHeight - PreferencesLayout.rowH
+        inlineImagesLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: gr0, width: graphicsLabelW, height: PreferencesLayout.rowH)
+        inlineImagesToggle.frame = PreferencesLayout.trailingToggleFrame(cardWidth: cardW, rowY: gr0)
+        inlineImagesNote.frame = NSRect(x: PreferencesLayout.cardPad, y: gr0 - 16, width: innerW, height: 14)
+        y += graphicsCardHeight + PreferencesLayout.sectionGap
 
         let behaviorCardHeight = behaviorCard.headerHeight + 4 * PreferencesLayout.rowH + 14 + 3 * PreferencesLayout.rowGap + PreferencesLayout.cardPad
         behaviorCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardW, height: behaviorCardHeight)

--- a/BellithTests/BellithSettingsTests.swift
+++ b/BellithTests/BellithSettingsTests.swift
@@ -120,6 +120,18 @@ final class BellithSettingsTests: XCTestCase {
         XCTAssertEqual(settings.windowPaddingY, 0)
     }
 
+    func testDefaultInlineImagesEnabled() {
+        XCTAssertTrue(settings.inlineImagesEnabled)
+    }
+
+    func testInlineImagesEnabledRoundtrip() {
+        settings.inlineImagesEnabled = false
+        XCTAssertFalse(settings.inlineImagesEnabled)
+
+        settings.inlineImagesEnabled = true
+        XCTAssertTrue(settings.inlineImagesEnabled)
+    }
+
     func testDefaultBuiltInSettingsWindowFeatureFlag() {
         XCTAssertFalse(settings.builtInSettingsWindowEnabled)
     }

--- a/BellithTests/TerminalConfigTests.swift
+++ b/BellithTests/TerminalConfigTests.swift
@@ -136,6 +136,24 @@ final class TerminalConfigTests: XCTestCase {
         XCTAssertTrue(contents.contains("window-padding-x = 9"))
     }
 
+    func testDefaultConfigOmitsImageStorageLimit() throws {
+        let path = try TerminalConfig.writeConfigFile(settings: settings)
+        let contents = try String(contentsOfFile: path, encoding: .utf8)
+
+        XCTAssertFalse(contents.contains("image-storage-limit"),
+                       "Default config should leave Ghostty's Kitty graphics / Sixel defaults untouched")
+    }
+
+    func testDisabledInlineImagesSetsImageStorageLimitToZero() throws {
+        settings.inlineImagesEnabled = false
+
+        let path = try TerminalConfig.writeConfigFile(settings: settings)
+        let contents = try String(contentsOfFile: path, encoding: .utf8)
+
+        XCTAssertTrue(contents.contains("image-storage-limit = 0"),
+                      "Disabling inline images should disable Ghostty's image storage")
+    }
+
     func testDisabledShellIntegrationWritesNone() throws {
         settings.shellIntegrationEnabled = false
 


### PR DESCRIPTION
## Summary
- Kitty graphics and Sixel already pass through GhosttyKit — this surfaces the capability with an explicit **Inline Images** toggle in the Terminal settings pane, defaulting on.
- When disabled, `image-storage-limit = 0` is emitted in `generated.conf` so Ghostty drops image payloads instead of rendering them.
- Adds settings persistence (`inlineImagesEnabled`) plus tests for the default-on and disabled-emit paths.

Closes #35

## Test plan
- [x] `xcodebuild … test -only-testing:BellithTests/TerminalConfigTests/testDefaultConfigOmitsImageStorageLimit`
- [x] `xcodebuild … test -only-testing:BellithTests/TerminalConfigTests/testDisabledInlineImagesSetsImageStorageLimitToZero`
- [x] `xcodebuild … test -only-testing:BellithTests/BellithSettingsTests/testDefaultInlineImagesEnabled`
- [x] `xcodebuild … test -only-testing:BellithTests/BellithSettingsTests/testInlineImagesEnabledRoundtrip`
- [ ] Manual: `icat`, `chafa`, `timg` render inline with the toggle on
- [ ] Manual: `gnuplot`/libsixel output renders inline with the toggle on
- [ ] Manual: toggling off hides image output after restarting the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)