### PR TITLE
feat(terminal): font ligatures toggle

### DIFF
--- a/Bellith/Bridge/TerminalConfig.swift
+++ b/Bellith/Bridge/TerminalConfig.swift
@@ -154,6 +154,13 @@ final class TerminalConfig {
         if !s.inlineImagesEnabled {
             lines.append("image-storage-limit = 0")
         }
+        if !s.fontLigaturesEnabled {
+            // Disable the common ligature OpenType features. Ghostty applies
+            // these features to all text; negative tags turn them off.
+            for tag in ["calt", "liga", "clig", "dlig"] {
+                lines.append("font-feature = -\(tag)")
+            }
+        }
         lines.append(contentsOf: macOSTerminalCompatibility.keybinds)
 
         do {

--- a/Bellith/Models/BellithSettings.swift
+++ b/Bellith/Models/BellithSettings.swift
@@ -79,6 +79,7 @@ final class BellithSettings {
             "showStatusBar", "showStatusBarContext", "showStatusBarPath",
             "showStatusBarGitWorktree", "showStatusBarGitBranch", "showStatusBarProcess",
             "showStatusBarGitHub", "showStatusBarSize",
+            "fontLigaturesEnabled",
         ]
         static let stringArrayKeys: Set<String> = [
             "sidebarTools",
@@ -126,6 +127,19 @@ final class BellithSettings {
     var fontSize: Int {
         get { let v = defaults.integer(forKey: "fontSize"); return v > 0 ? v : 15 }
         set { defaults.set(newValue, forKey: "fontSize"); notify() }
+    }
+
+    /// Programming ligatures (`calt`/`liga`/`clig`/`dlig` OpenType features).
+    /// Default is `true` — most programming fonts ship ligatures on and users
+    /// who chose Fira Code/JetBrains Mono/etc. expect them. When `false`,
+    /// the generated Ghostty config emits negative `font-feature` directives
+    /// to disable the common ligature feature tags.
+    var fontLigaturesEnabled: Bool {
+        get {
+            if defaults.object(forKey: "fontLigaturesEnabled") == nil { return true }
+            return defaults.bool(forKey: "fontLigaturesEnabled")
+        }
+        set { defaults.set(newValue, forKey: "fontLigaturesEnabled"); notify() }
     }
 
     var backgroundOpacity: Double {
@@ -891,6 +905,7 @@ final class BellithSettings {
             "cursorStyle": cursorStyle,
             "darkThemeName": darkThemeName,
             "fontFamily": fontFamily,
+            "fontLigaturesEnabled": fontLigaturesEnabled,
             "fontSize": fontSize,
             "featureFlags": featureFlagsForSettingsFile,
             "inlineImagesEnabled": inlineImagesEnabled,

--- a/Bellith/Views/Preferences/TerminalPane.swift
+++ b/Bellith/Views/Preferences/TerminalPane.swift
@@ -27,6 +27,8 @@ final class TerminalPane: NSView {
     private var sizeMinus: StepButton!
     private let sizeValue = ValueBadge()
     private var sizePlus: StepButton!
+    private let ligaturesLabel = CardRowLabel("Ligatures")
+    private var ligaturesToggle: PrefToggle!
 
     private let cursorCard = SettingsCard(title: "Cursor", subtitle: "Shape and motion of the active insertion point")
     private let cursorLabel = CardRowLabel("Cursor Style")
@@ -158,8 +160,11 @@ final class TerminalPane: NSView {
             self.sizeValue.stringValue = "\(self.settings.fontSize)"
             self.updateHero()
         }
+        ligaturesToggle = PrefToggle(isOn: settings.fontLigaturesEnabled) { [weak self] value in
+            self?.settings.fontLigaturesEnabled = value
+        }
         content.addSubview(fontCard)
-        for view: NSView in [fontSummaryLabel, fontSizeHeroLabel, fontPreviewNote, fontLabel, fontField, fontPickerBtn, sizeLabel, sizeMinus, sizeValue, sizePlus] {
+        for view: NSView in [fontSummaryLabel, fontSizeHeroLabel, fontPreviewNote, fontLabel, fontField, fontPickerBtn, sizeLabel, sizeMinus, sizeValue, sizePlus, ligaturesLabel, ligaturesToggle] {
             fontCard.addSubview(view)
         }
 
@@ -334,6 +339,7 @@ final class TerminalPane: NSView {
         sizeValue.stringValue = "\(settings.fontSize)"
         cursorSegment.setSelected(["block": 0, "bar": 1, "underline": 2][settings.cursorStyle] ?? 0)
         blinkToggle.setOn(settings.cursorBlink)
+        ligaturesToggle.setOn(settings.fontLigaturesEnabled)
         shellField.updateText(settings.shell)
         termField.updateText(settings.terminalTerm)
         cwdField.updateText(settings.workingDirectory)
@@ -402,7 +408,7 @@ final class TerminalPane: NSView {
         y += heroHeight + PreferencesLayout.sectionGap
 
         let fontHeroBlockH: CGFloat = 52
-        let fontCardHeight = fontCard.headerHeight + fontHeroBlockH + 2 * PreferencesLayout.rowH + PreferencesLayout.rowGap + PreferencesLayout.cardPad + 10
+        let fontCardHeight = fontCard.headerHeight + fontHeroBlockH + 3 * PreferencesLayout.rowH + 2 * PreferencesLayout.rowGap + PreferencesLayout.cardPad + 10
         fontCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardW, height: fontCardHeight)
         let fontHeroTop = fontCardHeight - fontCard.headerHeight - 14
         fontSummaryLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: fontHeroTop - 18, width: innerW - 110, height: 16)
@@ -420,6 +426,9 @@ final class TerminalPane: NSView {
         sizeMinus.frame = NSRect(x: controlX, y: fr1 + 6, width: stepSize, height: stepSize)
         sizeValue.frame = NSRect(x: controlX + 42, y: fr1 + 10, width: 54, height: 20)
         sizePlus.frame = NSRect(x: controlX + 110, y: fr1 + 6, width: stepSize, height: stepSize)
+        let fr2 = fr1 - PreferencesLayout.rowH - PreferencesLayout.rowGap
+        ligaturesLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: fr2, width: trailingToggleLabelWidth, height: PreferencesLayout.rowH)
+        ligaturesToggle.frame = PreferencesLayout.trailingToggleFrame(cardWidth: cardW, rowY: fr2)
         y += fontCardHeight + PreferencesLayout.sectionGap
 
         let cursorCardHeight = cursorCard.headerHeight + 3 * PreferencesLayout.rowH + 2 * PreferencesLayout.rowGap + PreferencesLayout.cardPad


### PR DESCRIPTION
## Summary
- New `fontLigaturesEnabled` setting (default **on**, matching current behavior).
- When disabled, `TerminalConfig` emits `font-feature = -calt`, `-liga`, `-clig`, `-dlig` so Ghostty turns off the common ligature OpenType features.
- UI toggle in **Preferences → Terminal** under the Font card. Persists to settings.json.

Closes #46

## Scope notes
Variable font axis sliders (the second bullet in the issue) are out of scope for this PR — they require per-font introspection of `fvar` axes and a dynamic slider layout. Filing as a follow-up.

## Test plan
- [ ] With Fira Code / JetBrains Mono selected, disable ligatures and confirm `==`/`!=`/`=>` render as separate glyphs after reopening sessions
- [ ] Re-enable and confirm ligatures return
- [ ] Confirm `settings.json` round-trips the new key