### PR TITLE
feat(tabs): pinned tabs

### DIFF
--- a/Bellith/Models/SessionState.swift
+++ b/Bellith/Models/SessionState.swift
@@ -41,12 +41,14 @@ struct SessionState: Codable {
         let smartPanelID: String?
         let terminalContext: TerminalContext?
         let sshProfileID: UUID?
+        let isPinned: Bool
 
         init(
             title: String,
             terminalSnapshot: TerminalSnapshot,
             terminalContext: TerminalContext? = nil,
-            sshProfileID: UUID? = nil
+            sshProfileID: UUID? = nil,
+            isPinned: Bool = false
         ) {
             self.title = title
             self.kind = .terminal
@@ -54,15 +56,17 @@ struct SessionState: Codable {
             self.smartPanelID = nil
             self.terminalContext = terminalContext
             self.sshProfileID = sshProfileID
+            self.isPinned = isPinned
         }
 
-        init(title: String, smartPanelID: String) {
+        init(title: String, smartPanelID: String, isPinned: Bool = false) {
             self.title = title
             self.kind = .smart
             self.terminalSnapshot = nil
             self.smartPanelID = smartPanelID
             self.terminalContext = nil
             self.sshProfileID = nil
+            self.isPinned = isPinned
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -73,6 +77,7 @@ struct SessionState: Codable {
             case terminalContext
             case sshProfileID
             case splitTree
+            case isPinned
         }
 
         init(from decoder: Decoder) throws {
@@ -82,6 +87,7 @@ struct SessionState: Codable {
             smartPanelID = try container.decodeIfPresent(String.self, forKey: .smartPanelID)
             terminalContext = try container.decodeIfPresent(TerminalContext.self, forKey: .terminalContext)
             sshProfileID = try container.decodeIfPresent(UUID.self, forKey: .sshProfileID)
+            isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
             if let snapshot = try container.decodeIfPresent(TerminalSnapshot.self, forKey: .terminalSnapshot) {
                 terminalSnapshot = snapshot
             } else if let legacySplitTree = try container.decodeIfPresent(SplitNodeState.self, forKey: .splitTree) {
@@ -99,6 +105,9 @@ struct SessionState: Codable {
             try container.encodeIfPresent(smartPanelID, forKey: .smartPanelID)
             try container.encodeIfPresent(terminalContext, forKey: .terminalContext)
             try container.encodeIfPresent(sshProfileID, forKey: .sshProfileID)
+            if isPinned {
+                try container.encode(isPinned, forKey: .isPinned)
+            }
         }
     }
 

--- a/Bellith/Services/TerminalSessionCoordinator.swift
+++ b/Bellith/Services/TerminalSessionCoordinator.swift
@@ -28,10 +28,11 @@ final class TerminalSessionCoordinator {
                     title: tab.title,
                     terminalSnapshot: snapshot,
                     terminalContext: context,
-                    sshProfileID: context?.sshProfileID
+                    sshProfileID: context?.sshProfileID,
+                    isPinned: tab.isPinned
                 )
             case .smart(let panel):
-                return SessionState.TabState(title: tab.title, smartPanelID: panel.pluginID)
+                return SessionState.TabState(title: tab.title, smartPanelID: panel.pluginID, isPinned: tab.isPinned)
             }
         }
 
@@ -99,6 +100,7 @@ final class TerminalSessionCoordinator {
                     cwd: nil,
                     localSessionBootstrap: terminalSnapshot.localSessionBootstrap,
                     localSessionName: terminalSnapshot.localSessionName,
+                    isPinned: tabState.isPinned,
                     content: .terminal(splitRoot: splitRoot, surfaces: [surface], focusedSurface: surface)
                 )
                 entry.cwd = surface.currentCwd
@@ -135,6 +137,7 @@ final class TerminalSessionCoordinator {
                     id: id,
                     title: tabState.title,
                     cwd: nil,
+                    isPinned: tabState.isPinned,
                     content: .smart(panel: panel)
                 )
                 restoredTabs.append(entry)

--- a/Bellith/Views/TabBarView.swift
+++ b/Bellith/Views/TabBarView.swift
@@ -8,6 +8,7 @@ final class TabBarView: NSView {
         let id: UUID
         var title: String
         var kind: TerminalContainerView.TabKind = .terminal
+        var isPinned: Bool = false
     }
 
     private(set) var tabs: [Tab] = []
@@ -18,6 +19,7 @@ final class TabBarView: NSView {
     var onCloseTab: ((Int) -> Void)?
     var onNewTab: (() -> Void)?
     var onReorderTab: ((Int, Int) -> Void)?
+    var onTogglePin: ((Int) -> Void)?
 
     private var dragSourceIndex: Int?
     private var dragTargetIndex: Int?
@@ -101,11 +103,13 @@ final class TabBarView: NSView {
             let pill = TabPillView(
                 title: tab.title,
                 isSelected: i == selectedIndex,
+                isPinned: tab.isPinned,
                 kind: tab.kind,
                 smartPanelRegistry: smartPanelRegistry
             )
             pill.onSelect = { [weak self] in self?.onSelectTab?(i) }
             pill.onClose = { [weak self] in self?.onCloseTab?(i) }
+            pill.onTogglePin = { [weak self] in self?.onTogglePin?(i) }
             pill.onDragBegan = { [weak self] in self?.beginDrag(fromIndex: i) }
             pill.onDragMoved = { [weak self] loc in self?.updateDrag(location: loc) }
             pill.onDragEnded = { [weak self] in self?.endDrag() }
@@ -206,6 +210,7 @@ final class TabBarView: NSView {
 fileprivate final class TabPillView: NSView {
     var onSelect: (() -> Void)?
     var onClose: (() -> Void)?
+    var onTogglePin: (() -> Void)?
     var onDragBegan: (() -> Void)?
     var onDragMoved: ((NSPoint) -> Void)?
     var onDragEnded: (() -> Void)?
@@ -215,17 +220,21 @@ fileprivate final class TabPillView: NSView {
     override var mouseDownCanMoveWindow: Bool { false }
 
     private let iconView = NSImageView()
+    private let pinView = NSImageView()
     private let titleLabel = NSTextField(labelWithString: "")
     private let closeButton = NSButton()
     private let isSelected: Bool
+    private let isPinned: Bool
     private let kind: TerminalContainerView.TabKind
     private let smartPanelRegistry: SmartPanelRegistry
     private var trackingArea: NSTrackingArea?
     private var isHovered = false
 
     var idealWidth: CGFloat {
-        let iconWidth: CGFloat = isSmartTab ? 22 : 0
-        return titleLabel.attributedStringValue.size().width + 40 + iconWidth
+        let iconWidth: CGFloat = (isSmartTab || isPinned) ? 22 : 0
+        // Pinned tabs render compactly — no trailing close button gap.
+        let trailing: CGFloat = isPinned ? 20 : 40
+        return titleLabel.attributedStringValue.size().width + trailing + iconWidth
     }
 
     private var isSmartTab: Bool {
@@ -236,10 +245,12 @@ fileprivate final class TabPillView: NSView {
     init(
         title: String,
         isSelected: Bool,
+        isPinned: Bool,
         kind: TerminalContainerView.TabKind,
         smartPanelRegistry: SmartPanelRegistry
     ) {
         self.isSelected = isSelected
+        self.isPinned = isPinned
         self.kind = kind
         self.smartPanelRegistry = smartPanelRegistry
         super.init(frame: .zero)
@@ -249,16 +260,22 @@ fileprivate final class TabPillView: NSView {
 
         // Accessibility
         setAccessibilityRole(.button)
-        setAccessibilityLabel("Tab: \(title)")
+        let pinnedSuffix = isPinned ? ", pinned" : ""
+        setAccessibilityLabel("Tab: \(title)\(pinnedSuffix)")
         setAccessibilityValue(isSelected ? "selected" : "")
 
-        // Icon for smart tabs
+        // Leading icon: smart-tab icon takes priority over pin glyph.
         if case .smart(let pluginID) = kind,
            let plugin = smartPanelRegistry.plugin(for: pluginID) {
             iconView.image = NSImage(systemSymbolName: plugin.iconName, accessibilityDescription: nil)
             iconView.contentTintColor = isSelected ? Theme.textPrimary : Theme.textTertiary
             iconView.imageScaling = .scaleProportionallyDown
             addSubview(iconView)
+        } else if isPinned {
+            pinView.image = NSImage(systemSymbolName: "pin.fill", accessibilityDescription: "Pinned")
+            pinView.contentTintColor = isSelected ? Theme.accent : Theme.textTertiary
+            pinView.imageScaling = .scaleProportionallyDown
+            addSubview(pinView)
         }
 
         titleLabel.stringValue = title
@@ -268,15 +285,17 @@ fileprivate final class TabPillView: NSView {
         titleLabel.maximumNumberOfLines = 1
         addSubview(titleLabel)
 
-        closeButton.isBordered = false
-        closeButton.title = ""
-        closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Close")
-        closeButton.contentTintColor = Theme.textTertiary
-        closeButton.setFrameSize(NSSize(width: 18, height: 18))
-        closeButton.target = self
-        closeButton.action = #selector(handleClose)
-        closeButton.alphaValue = 0
-        addSubview(closeButton)
+        if !isPinned {
+            closeButton.isBordered = false
+            closeButton.title = ""
+            closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Close")
+            closeButton.contentTintColor = Theme.textTertiary
+            closeButton.setFrameSize(NSSize(width: 18, height: 18))
+            closeButton.target = self
+            closeButton.action = #selector(handleClose)
+            closeButton.alphaValue = 0
+            addSubview(closeButton)
+        }
 
         updateAppearance()
     }
@@ -291,10 +310,16 @@ fileprivate final class TabPillView: NSView {
         if isSmartTab {
             iconView.frame = NSRect(x: 10, y: (bounds.height - 12) / 2, width: 12, height: 12)
             labelX = 28
+        } else if isPinned {
+            pinView.frame = NSRect(x: 10, y: (bounds.height - 11) / 2, width: 11, height: 11)
+            labelX = 26
         }
 
-        titleLabel.frame = NSRect(x: labelX, y: (bounds.height - 16) / 2, width: bounds.width - labelX - 28, height: 16)
-        closeButton.frame = NSRect(x: bounds.width - 24, y: (bounds.height - 18) / 2, width: 18, height: 18)
+        let trailingInset: CGFloat = isPinned ? 10 : 28
+        titleLabel.frame = NSRect(x: labelX, y: (bounds.height - 16) / 2, width: max(0, bounds.width - labelX - trailingInset), height: 16)
+        if !isPinned {
+            closeButton.frame = NSRect(x: bounds.width - 24, y: (bounds.height - 18) / 2, width: 18, height: 18)
+        }
     }
 
     override func updateTrackingAreas() {
@@ -312,6 +337,7 @@ fileprivate final class TabPillView: NSView {
     override func mouseEntered(with event: NSEvent) {
         isHovered = true
         updateAppearance()
+        guard !isPinned else { return }
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = Theme.animFast
             closeButton.animator().alphaValue = 1
@@ -321,10 +347,30 @@ fileprivate final class TabPillView: NSView {
     override func mouseExited(with event: NSEvent) {
         isHovered = false
         updateAppearance()
+        guard !isPinned else { return }
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = Theme.animFast
             closeButton.animator().alphaValue = 0
         }
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        let menu = NSMenu()
+        let pinTitle = isPinned ? "Unpin Tab" : "Pin Tab"
+        let pinItem = NSMenuItem(title: pinTitle, action: #selector(handleTogglePin), keyEquivalent: "")
+        pinItem.target = self
+        menu.addItem(pinItem)
+        if !isPinned {
+            menu.addItem(.separator())
+            let closeItem = NSMenuItem(title: "Close Tab", action: #selector(handleClose), keyEquivalent: "")
+            closeItem.target = self
+            menu.addItem(closeItem)
+        }
+        NSMenu.popUpContextMenu(menu, with: event, for: self)
+    }
+
+    @objc private func handleTogglePin() {
+        onTogglePin?()
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -118,6 +118,7 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         tabBar.onCloseTab = { [weak self] i in self?.closeTab(i) }
         tabBar.onNewTab = { [weak self] in self?.createTab() }
         tabBar.onReorderTab = { [weak self] from, to in self?.reorderTab(from: from, to: to) }
+        tabBar.onTogglePin = { [weak self] i in self?.togglePinTab(i) }
 
         // Status bar (optional, shown beneath the terminal content)
         statusBar.onVisibilityChanged = { [weak self] visible in
@@ -813,8 +814,37 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         createSmartTab(pluginID: pluginID)
     }
 
+    /// Toggle the pinned state of a tab. Pinning moves the tab to the left of
+    /// the first non-pinned tab; unpinning leaves it in place within the pin
+    /// region, which becomes the first non-pinned slot.
+    func togglePinTab(_ index: Int) {
+        guard index >= 0, index < tabs.count else { return }
+        tabs[index].isPinned.toggle()
+        rebalancePinnedOrder()
+        refreshTabUI()
+    }
+
+    /// Ensure pinned tabs are contiguous and leftmost without otherwise
+    /// disturbing the relative order of tabs within the pinned and unpinned
+    /// segments.
+    private func rebalancePinnedOrder() {
+        guard !tabs.isEmpty else { return }
+        let selectedId = tabs.indices.contains(selectedTabIndex) ? tabs[selectedTabIndex].id : nil
+        let pinned = tabs.filter { $0.isPinned }
+        let unpinned = tabs.filter { !$0.isPinned }
+        tabs = pinned + unpinned
+        if let selectedId, let newIndex = tabs.firstIndex(where: { $0.id == selectedId }) {
+            selectedTabIndex = newIndex
+        }
+    }
+
     func closeTab(_ index: Int) {
         guard index < tabs.count, !isClosingTab else { return }
+        // Pinned tabs are protected from accidental close. Unpin first.
+        if tabs[index].isPinned {
+            NSSound.beep()
+            return
+        }
         isClosingTab = true
 
         let entry = tabs[index]
@@ -882,8 +912,22 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
               sourceIndex >= 0, sourceIndex < tabs.count,
               destinationIndex >= 0, destinationIndex < tabs.count else { return }
 
+        // Clamp destination so pinned tabs stay leftmost and unpinned tabs
+        // stay to the right of the pinned block.
+        let pinnedCount = tabs.filter { $0.isPinned }.count
+        let movingPinned = tabs[sourceIndex].isPinned
+        var clampedDestination = destinationIndex
+        if movingPinned {
+            clampedDestination = min(clampedDestination, max(0, pinnedCount - 1))
+        } else {
+            clampedDestination = max(clampedDestination, pinnedCount)
+        }
+        guard clampedDestination != sourceIndex else { return }
+
         let tab = tabs.remove(at: sourceIndex)
-        tabs.insert(tab, at: destinationIndex)
+        tabs.insert(tab, at: clampedDestination)
+
+        let destinationIndex = clampedDestination
 
         if selectedTabIndex == sourceIndex {
             selectedTabIndex = destinationIndex
@@ -1149,7 +1193,7 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         let tabData = tabs.map { (id: $0.id, title: $0.title, kind: $0.kind) }
         sidebar.update(tabs: tabData, selectedIndex: selectedTabIndex)
 
-        let barTabs = tabs.map { TabBarView.Tab(id: $0.id, title: $0.title, kind: $0.kind) }
+        let barTabs = tabs.map { TabBarView.Tab(id: $0.id, title: $0.title, kind: $0.kind, isPinned: $0.isPinned) }
         tabBar.update(tabs: barTabs, selectedIndex: selectedTabIndex)
     }
 
@@ -1355,9 +1399,20 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         guard index < tabs.count else { return }
         let menu = NSMenu()
 
+        let pinItem = NSMenuItem(
+            title: tabs[index].isPinned ? "Unpin Tab" : "Pin Tab",
+            action: #selector(contextMenuTogglePin(_:)),
+            keyEquivalent: ""
+        )
+        pinItem.representedObject = index
+        pinItem.target = self
+        menu.addItem(pinItem)
+        menu.addItem(.separator())
+
         let closeItem = NSMenuItem(title: "Close Tab", action: #selector(contextMenuCloseTab(_:)), keyEquivalent: "")
         closeItem.representedObject = index
         closeItem.target = self
+        closeItem.isEnabled = !tabs[index].isPinned
         menu.addItem(closeItem)
 
         if tabs.count > 1 {
@@ -1398,7 +1453,8 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         let keepId = tabs[keepIndex].id
         var i = tabs.count - 1
         while i >= 0 {
-            if tabs[i].id != keepId { closeTab(i) }
+            // Skip pinned tabs — they're protected from bulk-close.
+            if tabs[i].id != keepId && !tabs[i].isPinned { closeTab(i) }
             i -= 1
         }
     }
@@ -1407,9 +1463,14 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         guard let index = sender.representedObject as? Int else { return }
         var i = tabs.count - 1
         while i > index {
-            closeTab(i)
+            if !tabs[i].isPinned { closeTab(i) }
             i -= 1
         }
+    }
+
+    @objc private func contextMenuTogglePin(_ sender: NSMenuItem) {
+        guard let index = sender.representedObject as? Int else { return }
+        togglePinTab(index)
     }
 
     @objc private func contextMenuDuplicateTab(_ sender: NSMenuItem) {

--- a/Bellith/Views/TerminalTabModel.swift
+++ b/Bellith/Views/TerminalTabModel.swift
@@ -22,6 +22,7 @@ struct TerminalTabEntry {
     var cwd: String?
     var localSessionBootstrap: SSHSessionBootstrap?
     var localSessionName: String?
+    var isPinned: Bool = false
     var content: TerminalTabContent
 
     var kind: TerminalTabKind {


### PR DESCRIPTION
## Summary
Adds tab pinning.

- **Visual** — pinned tabs render a filled `pin.fill` glyph instead of the hover close button and sit contiguously at the left of the tab bar.
- **Protection** — `closeTab` beeps on pinned tabs; "Close Other Tabs" and "Close Tabs to the Right" skip pinned tabs.
- **Context menus** — right-click on a `TabPillView` shows Pin/Unpin + Close; the sidebar tab context menu gains the same Pin/Unpin action and disables Close while pinned.
- **Reorder clamp** — `reorderTab` clamps the destination so pinned tabs stay leftmost and unpinned tabs stay to their right.
- **Persistence** — `SessionState.TabState.isPinned` is optional and backwards-compatible (only emits when `true`), so existing session files continue to load.

Closes #43

## Scope notes
The issue also mentions **collapsible tab groups with color labels**. Groups are a significantly larger feature (group header view, new model type, drag-into-group, persistence schema) and are left for a dedicated follow-up PR. This PR delivers the pinned-tab half of the acceptance criteria, including session persistence.

## Test plan
- [ ] Right-click a tab → Pin Tab → confirm pin glyph appears, tab moves left, no close button on hover
- [ ] Right-click again → Unpin → confirm it returns to unpinned state
- [ ] With a pinned tab, click ✕/use ⌘W → confirm beep and no close
- [ ] "Close Other Tabs" and "Close Tabs to the Right" — pinned tabs remain
- [ ] Reorder: drag an unpinned tab toward the start — it clamps after the last pinned tab
- [ ] Quit + relaunch (session restore on) — pinned state survives