### PR TITLE
feat(theming): per-profile transparency, blur, and wallpaper tint

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		3AA2DA3E813BBA3E1B8CF1B9 /* SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AD21D2101DAB69E92DFB59 /* SessionState.swift */; };
 		3F067DBCA20A52FB30980DA2 /* SSHProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AC775F3A6A91CF3FE4CDAB /* SSHProfileStoreTests.swift */; };
 		3F81E95CDC0FF4142056C98A /* EnvironmentPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0B5E50A6BE76A1D3EDFE6D /* EnvironmentPanel.swift */; };
+		3FE2152821D44C82B14D0338 /* WallpaperTint.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD317F56432F400BA1567BB /* WallpaperTint.swift */; };
 		459FB063C7F788F4E0E549A5 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89FDA87579791818D3A6718 /* TerminalPane.swift */; };
 		462CADCA785D176937B5F445 /* GitRepositoryInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC203E445CE586B521D8FC29 /* GitRepositoryInfoTests.swift */; };
 		4859630C40EA72D0F6A13448 /* SSHLaunchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A6320778E024E8ABCDF2A6 /* SSHLaunchBuilder.swift */; };
@@ -90,6 +91,7 @@
 		DAF1FF85E2B99E346EE83564 /* ToolActivityPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAC0EE06A46735764D38F77 /* ToolActivityPanel.swift */; };
 		DBFD98B2DDBABADA6AA755D7 /* TerminalApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B2F8E9E8CAEFBB81287640 /* TerminalApp.swift */; };
 		DDDD63014E36721A941C97E4 /* TerminalProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772785F1920803E52A7235C8 /* TerminalProfile.swift */; };
+		E450123DFE8F0EBAD8050A69 /* BackdropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27A4F297624101EA6EA1124 /* BackdropView.swift */; };
 		E90F976F4D03F92405690751 /* GitHubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419904C2F6EF539F340C4054 /* GitHubService.swift */; };
 		F0688F637632B59A01825393 /* TerminalContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72367912169712669D03FD67 /* TerminalContainerView.swift */; };
 		F26474311EB82215B71E0CE0 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC69484808B270DA784451B1 /* SearchBarView.swift */; };
@@ -188,6 +190,7 @@
 		B8917D92D4F8962901183EEA /* ThemeGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeGridView.swift; sourceTree = "<group>"; };
 		BB30AA7FAF949D6830C55830 /* ShortcutCheatSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCheatSheetView.swift; sourceTree = "<group>"; };
 		BC1465B59AFD1A458C9669E1 /* BellithDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellithDependencies.swift; sourceTree = "<group>"; };
+		C27A4F297624101EA6EA1124 /* BackdropView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackdropView.swift; sourceTree = "<group>"; };
 		C2EA413DA31A6997580EEAF8 /* SSHSessionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHSessionDetectorTests.swift; sourceTree = "<group>"; };
 		C6D8A2F2C2B69B1DF8B695CA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C6E1C3DB1ADB2A4903FA2FF2 /* TerminalRuntimeInfoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRuntimeInfoService.swift; sourceTree = "<group>"; };
@@ -210,6 +213,7 @@
 		F2088BFA03DDDC079DE5DB8C /* HyperlinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperlinkRouter.swift; sourceTree = "<group>"; };
 		F9994A85D37354E2BFF60705 /* CommandPaletteViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteViewTests.swift; sourceTree = "<group>"; };
 		FC5966D19E6F059737E8B875 /* TerminalContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalContext.swift; sourceTree = "<group>"; };
+		FCD317F56432F400BA1567BB /* WallpaperTint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperTint.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -299,6 +303,7 @@
 		2E5B61C6FBAE38CE1F2A2657 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				C27A4F297624101EA6EA1124 /* BackdropView.swift */,
 				8AF3103FA440F936419F4846 /* BlurView.swift */,
 				52E9612F02A1A65DFA8CA240 /* CommandPaletteView.swift */,
 				7B6A4E8E8C5D7B65BB385570 /* ContextBadgeView.swift */,
@@ -406,6 +411,7 @@
 				C6E1C3DB1ADB2A4903FA2FF2 /* TerminalRuntimeInfoService.swift */,
 				707A2AF28DE5D2F8EA639BFB /* TerminalSessionCoordinator.swift */,
 				EE6157DFCE204C3ADC26FA72 /* ToolActivityMonitor.swift */,
+				FCD317F56432F400BA1567BB /* WallpaperTint.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -619,6 +625,7 @@
 				9BF5A978A5AACAB4DD91124B /* AboutPane.swift in Sources */,
 				A497CDCB9182E12C715A1A43 /* AppDelegate.swift in Sources */,
 				CF4A12A757D3355AEB4D159A /* AppearancePane.swift in Sources */,
+				E450123DFE8F0EBAD8050A69 /* BackdropView.swift in Sources */,
 				26A609DD7125866A18244E1D /* BellithBranding.swift in Sources */,
 				A46704CAA2427B9557BE7973 /* BellithDependencies.swift in Sources */,
 				CCA0508AE25C077D19B7319C /* BellithFont.swift in Sources */,
@@ -684,6 +691,7 @@
 				BAF7DA9CF2672F1E616A7F17 /* TitleBarView.swift in Sources */,
 				55B5329D0C164FDCBEE88A5D /* ToolActivityMonitor.swift in Sources */,
 				DAF1FF85E2B99E346EE83564 /* ToolActivityPanel.swift in Sources */,
+				3FE2152821D44C82B14D0338 /* WallpaperTint.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bellith/App/AppDelegate.swift
+++ b/Bellith/App/AppDelegate.swift
@@ -209,7 +209,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         window.delegate = self
 
         let container = TerminalContainerView(terminalApp: terminalApp, dependencies: dependencies)
-        window.contentView = container
+        let backdrop = BackdropView(container: container)
+        window.contentView = backdrop
 
         let entry = WindowEntry(window: window, container: container)
         windows.append(entry)

--- a/Bellith/Bridge/TerminalConfig.swift
+++ b/Bellith/Bridge/TerminalConfig.swift
@@ -77,7 +77,10 @@ final class TerminalConfig {
     private(set) var config: ghostty_config_t?
     private(set) var configurationError: TerminalConfigError?
 
-    init(configurationDirectory: URL? = nil) {
+    init(
+        settings: BellithSettings = .shared,
+        configurationDirectory: URL? = nil
+    ) {
         config = ghostty_config_new()
         guard config != nil else {
             report(.failedToCreateGhosttyConfig)
@@ -85,7 +88,10 @@ final class TerminalConfig {
         }
 
         do {
-            let generatedConfigPath = try Self.writeConfigFile(configurationDirectory: configurationDirectory)
+            let generatedConfigPath = try Self.writeConfigFile(
+                settings: settings,
+                configurationDirectory: configurationDirectory
+            )
             generatedConfigPath.withCString { ghostty_config_load_file(config, $0) }
         } catch let error as TerminalConfigError {
             report(error)
@@ -131,7 +137,8 @@ final class TerminalConfig {
             "font-size = \(s.fontSize)",
             "theme = \(themeReference)",
             "term = \(s.effectiveTerminalTerm)",
-            "background-opacity = \(s.backgroundOpacity)",
+            "background-opacity = \(s.activeProfile.effectiveBackgroundOpacity(fallback: s))",
+            "background-blur-radius = \(Self.backgroundBlurRadius(for: s.activeProfile))",
             "window-padding-x = \(Self.windowPaddingXValue(for: s))",
             "window-padding-y = \(Self.windowPaddingYValue(for: s))",
             "window-padding-balance = false",
@@ -234,6 +241,15 @@ final class TerminalConfig {
         } catch {
             throw TerminalConfigError.failedToWriteThemeFile(file, underlying: error)
         }
+    }
+
+    /// Map the profile's 0–1 blur slider onto Ghostty's pixel-valued
+    /// `background-blur-radius`. 0 disables the native blur; 1 pins it to a
+    /// heavy frost.
+    private static func backgroundBlurRadius(for profile: TerminalProfile) -> Int {
+        let intensity = profile.effectiveBlurIntensity()
+        guard intensity > 0 else { return 0 }
+        return max(1, Int((intensity * 40).rounded()))
     }
 
     private static func windowPaddingXValue(for settings: BellithSettings) -> Int {

--- a/Bellith/Models/BellithSettings.swift
+++ b/Bellith/Models/BellithSettings.swift
@@ -60,6 +60,7 @@ final class BellithSettings {
             "shell", "terminalTerm", "visorHotkey", "visorPosition", "workingDirectory",
             "bellMode", "wordSeparators", "shortcutPreset", "localSessionBootstrap",
             "terminalOptionKeyBehavior", "appearanceMode",
+            "activeTerminalProfileID",
         ]
         static let intKeys: Set<String> = [
             "fontSize", "scrollbackLines", "commandCompletionNotificationThreshold",
@@ -86,12 +87,13 @@ final class BellithSettings {
         ]
         static let featureFlags = "featureFlags"
         static let keybindings = "keybindings"
+        static let terminalProfiles = "terminalProfiles"
         static let all: Set<String> = stringKeys
             .union(intKeys)
             .union(doubleKeys)
             .union(boolKeys)
             .union(stringArrayKeys)
-            .union([featureFlags, keybindings])
+            .union([featureFlags, keybindings, terminalProfiles])
     }
 
     let defaults: UserDefaults
@@ -110,6 +112,7 @@ final class BellithSettings {
         self.settingsFileURL = settingsFileURL ?? Self.defaultSettingsFileURL(for: defaults)
         loadSettingsFileIfNeeded()
         migrateLegacyWindowPaddingIfNeeded()
+        migrateLegacyBackgroundOpacityToDefaultProfileIfNeeded()
         persistSettingsFileIfNeeded()
         startObservingSettingsFileIfNeeded()
     }
@@ -729,6 +732,19 @@ final class BellithSettings {
         defaults.set(WindowPaddingDefaults.current, forKey: "windowPaddingY")
     }
 
+    /// Seed the default profile's backgroundOpacity from the legacy global value
+    /// so pre-existing installs preserve their chosen translucency after moving
+    /// to per-profile storage.
+    private func migrateLegacyBackgroundOpacityToDefaultProfileIfNeeded() {
+        var list = profiles
+        guard let defaultIndex = list.firstIndex(where: { $0.id == TerminalProfile.defaultID }),
+              list[defaultIndex].backgroundOpacity == nil else {
+            return
+        }
+        list[defaultIndex].backgroundOpacity = backgroundOpacity
+        profiles = list
+    }
+
     static let defaultKeybindings: [KeyBindingEntry] = defaultKeybindings(for: .bellithHybrid, legacyPaneSupport: false)
 
     static func defaultKeybindings(
@@ -868,6 +884,13 @@ final class BellithSettings {
             guard let dictionaryValue = value as? [String: Any] else { return }
             defaults.set(Self.featureFlags(from: dictionaryValue), forKey: key)
 
+        case PersistedKeys.terminalProfiles:
+            guard JSONSerialization.isValidJSONObject(value),
+                  let jsonData = try? JSONSerialization.data(withJSONObject: value),
+                  let decoded = try? JSONDecoder().decode([TerminalProfile].self, from: jsonData),
+                  let encoded = try? JSONEncoder().encode(decoded) else { return }
+            defaults.set(encoded, forKey: key)
+
         case _ where PersistedKeys.stringArrayKeys.contains(key):
             guard let arrayValue = value as? [String] else { return }
             defaults.set(arrayValue, forKey: key)
@@ -900,7 +923,16 @@ final class BellithSettings {
             encodedKeybindings = []
         }
 
+        let encodedProfiles: Any
+        do {
+            let encoded = try JSONEncoder().encode(profiles)
+            encodedProfiles = try JSONSerialization.jsonObject(with: encoded)
+        } catch {
+            encodedProfiles = []
+        }
+
         let object: [String: Any] = [
+            "activeTerminalProfileID": activeProfileID,
             "appearanceMode": appearanceMode.rawValue,
             "backgroundOpacity": roundedForSettingsFile(backgroundOpacity),
             "bellMode": bellMode,
@@ -944,6 +976,7 @@ final class BellithSettings {
             "sidebarShowTools": sidebarShowTools,
             "sidebarTools": sidebarTools,
             "tabMode": tabMode,
+            "terminalProfiles": encodedProfiles,
             "terminalOptionKeyBehavior": terminalOptionKeyBehavior.rawValue,
             "terminalTerm": terminalTerm,
             "trafficLightAutoHide": trafficLightAutoHide,

--- a/Bellith/Models/TerminalProfile.swift
+++ b/Bellith/Models/TerminalProfile.swift
@@ -2,17 +2,27 @@ import Foundation
 
 // MARK: - Profiles
 
-struct TerminalProfile: Codable, Identifiable {
-    var id: String  // unique key, e.g. "default", "ssh-prod"
+struct TerminalProfile: Codable, Identifiable, Equatable {
+    var id: String  // unique key, e.g. "default", "focus"
     var name: String
-    var fontFamily: String?  // nil = use global setting
+    var fontFamily: String?
     var fontSize: Int?
     var themeName: String?
     var shell: String?
     var workingDirectory: String?
     var cursorStyle: String?
 
-    /// Merge this profile's overrides onto the global settings to produce a config.
+    /// Background opacity in [0.0, 1.0]. `nil` falls back to the global setting.
+    var backgroundOpacity: Double?
+
+    /// Blur intensity in [0.0, 1.0]. 0 disables the visual-effect backdrop;
+    /// higher values pick a heavier `NSVisualEffectView.Material`.
+    var blurIntensity: Double?
+
+    /// When true, a muted accent derived from the desktop wallpaper is
+    /// overlaid on the translucent window chrome.
+    var wallpaperTint: Bool?
+
     func effectiveFont(fallback: BellithSettings) -> String {
         fontFamily ?? fallback.fontFamily
     }
@@ -25,26 +35,68 @@ struct TerminalProfile: Codable, Identifiable {
         shell ?? fallback.shell
     }
 
-    static let `default` = TerminalProfile(
-        id: "default", name: "Default"
-    )
+    func effectiveBackgroundOpacity(fallback: BellithSettings) -> Double {
+        let value = backgroundOpacity ?? fallback.backgroundOpacity
+        return min(max(value, 0.0), 1.0)
+    }
+
+    func effectiveBlurIntensity() -> Double {
+        min(max(blurIntensity ?? 0.0, 0.0), 1.0)
+    }
+
+    func effectiveWallpaperTint() -> Bool {
+        wallpaperTint ?? false
+    }
+
+    static let defaultID = "default"
+
+    static let `default` = TerminalProfile(id: defaultID, name: "Default")
 }
 
 extension BellithSettings {
+    private static let profilesKey = "terminalProfiles"
+    private static let activeProfileIDKey = "activeTerminalProfileID"
+
     var profiles: [TerminalProfile] {
         get {
-            if let data = defaults.data(forKey: "profiles"),
-               let decoded = try? JSONDecoder().decode([TerminalProfile].self, from: data) {
+            if let data = defaults.data(forKey: Self.profilesKey),
+               let decoded = try? JSONDecoder().decode([TerminalProfile].self, from: data),
+               !decoded.isEmpty {
                 return decoded
             }
             return [.default]
         }
         set {
-            if let data = try? JSONEncoder().encode(newValue) {
-                defaults.set(data, forKey: "profiles")
+            let sanitized = newValue.isEmpty ? [.default] : newValue
+            if let data = try? JSONEncoder().encode(sanitized) {
+                defaults.set(data, forKey: Self.profilesKey)
             }
             notify()
         }
+    }
+
+    var activeProfileID: String {
+        get {
+            let stored = defaults.string(forKey: Self.activeProfileIDKey) ?? TerminalProfile.defaultID
+            return profiles.contains(where: { $0.id == stored }) ? stored : TerminalProfile.defaultID
+        }
+        set {
+            defaults.set(newValue, forKey: Self.activeProfileIDKey)
+            notify()
+        }
+    }
+
+    var activeProfile: TerminalProfile {
+        let list = profiles
+        return list.first(where: { $0.id == activeProfileID }) ?? list.first ?? .default
+    }
+
+    func updateActiveProfile(_ mutate: (inout TerminalProfile) -> Void) {
+        var list = profiles
+        let id = activeProfileID
+        guard let index = list.firstIndex(where: { $0.id == id }) else { return }
+        mutate(&list[index])
+        profiles = list
     }
 
     func profile(named name: String) -> TerminalProfile? {

--- a/Bellith/Services/WallpaperTint.swift
+++ b/Bellith/Services/WallpaperTint.swift
@@ -1,0 +1,130 @@
+import AppKit
+
+/// Samples the desktop wallpaper on each screen and exposes a muted accent
+/// color suitable for tinting translucent window backgrounds. The sample is
+/// cached until the wallpaper changes or a space switch occurs.
+final class WallpaperTint {
+    static let shared = WallpaperTint()
+    static let didChangeNotification = Notification.Name("WallpaperTintDidChange")
+
+    private var cache: [ObjectIdentifier: NSColor] = [:]
+    private var observers: [NSObjectProtocol] = []
+
+    private init() {
+        let center = NSWorkspace.shared.notificationCenter
+        let spaceObserver = center.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.invalidate()
+        }
+        observers.append(spaceObserver)
+    }
+
+    deinit {
+        let center = NSWorkspace.shared.notificationCenter
+        for observer in observers {
+            center.removeObserver(observer)
+        }
+    }
+
+    /// Returns a cached muted accent for the given screen's wallpaper, or the
+    /// app's accent color as a fallback if sampling fails.
+    func accent(for screen: NSScreen?) -> NSColor {
+        guard let screen else { return fallbackAccent }
+        let key = ObjectIdentifier(screen)
+        if let cached = cache[key] { return cached }
+        let color = sample(screen: screen) ?? fallbackAccent
+        cache[key] = color
+        return color
+    }
+
+    func invalidate() {
+        cache.removeAll()
+        NotificationCenter.default.post(name: Self.didChangeNotification, object: self)
+    }
+
+    private var fallbackAccent: NSColor {
+        NSColor.controlAccentColor.withAlphaComponent(1.0)
+    }
+
+    private func sample(screen: NSScreen) -> NSColor? {
+        guard let imageURL = NSWorkspace.shared.desktopImageURL(for: screen),
+              let source = CGImageSourceCreateWithURL(imageURL as CFURL, nil),
+              let cgImage = CGImageSourceCreateThumbnailAtIndex(
+                  source,
+                  0,
+                  [
+                      kCGImageSourceCreateThumbnailFromImageAlways: true,
+                      kCGImageSourceThumbnailMaxPixelSize: 64,
+                      kCGImageSourceCreateThumbnailWithTransform: true,
+                  ] as CFDictionary
+              )
+        else { return nil }
+
+        return Self.averagedMutedColor(from: cgImage)
+    }
+
+    private static func averagedMutedColor(from image: CGImage) -> NSColor? {
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return nil }
+
+        let bytesPerPixel = 4
+        let bytesPerRow = bytesPerPixel * width
+        let bitsPerComponent = 8
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var data = [UInt8](repeating: 0, count: width * height * bytesPerPixel)
+
+        guard let context = CGContext(
+            data: &data,
+            width: width,
+            height: height,
+            bitsPerComponent: bitsPerComponent,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        var totalR: Double = 0
+        var totalG: Double = 0
+        var totalB: Double = 0
+        var samples: Double = 0
+        var i = 0
+        while i < data.count {
+            let r = Double(data[i]) / 255.0
+            let g = Double(data[i + 1]) / 255.0
+            let b = Double(data[i + 2]) / 255.0
+            // Drop near-black and near-white so the tint picks up chroma
+            // instead of shadows or skies.
+            let lum = 0.299 * r + 0.587 * g + 0.114 * b
+            if lum > 0.1 && lum < 0.9 {
+                totalR += r
+                totalG += g
+                totalB += b
+                samples += 1
+            }
+            i += bytesPerPixel
+        }
+
+        guard samples > 0 else { return nil }
+        let avgR = CGFloat(totalR / samples)
+        let avgG = CGFloat(totalG / samples)
+        let avgB = CGFloat(totalB / samples)
+
+        // Desaturate slightly so the tint stays subtle.
+        let base = NSColor(srgbRed: avgR, green: avgG, blue: avgB, alpha: 1.0)
+        guard let hsb = base.usingColorSpace(.sRGB) else { return base }
+        let saturation = max(0.2, min(hsb.saturationComponent * 0.7, 0.55))
+        let brightness = max(0.25, min(hsb.brightnessComponent, 0.65))
+        return NSColor(
+            hue: hsb.hueComponent,
+            saturation: saturation,
+            brightness: brightness,
+            alpha: 1.0
+        )
+    }
+}

--- a/Bellith/Views/BackdropView.swift
+++ b/Bellith/Views/BackdropView.swift
@@ -1,0 +1,85 @@
+import AppKit
+
+/// Root window content view that hosts a terminal container and provides a
+/// translucent material behind it. Used so profiles with
+/// `backgroundOpacity < 1` have a visible backdrop instead of the raw desktop
+/// when Ghostty composites its alpha pixels.
+final class BackdropView: NSVisualEffectView {
+    let container: TerminalContainerView
+    private let tintLayer = CALayer()
+
+    init(container: TerminalContainerView) {
+        self.container = container
+        super.init(frame: .zero)
+        blendingMode = .behindWindow
+        state = .active
+        material = .hudWindow
+        wantsLayer = true
+        layer?.masksToBounds = true
+
+        tintLayer.backgroundColor = NSColor.clear.cgColor
+        layer?.addSublayer(tintLayer)
+
+        container.autoresizingMask = [.width, .height]
+        addSubview(container)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layout() {
+        super.layout()
+        container.frame = bounds
+        tintLayer.frame = bounds
+    }
+
+    /// Update the material and tint for the given profile. Called whenever
+    /// settings or the active profile change.
+    func apply(profile: TerminalProfile, fallback: BellithSettings, screen: NSScreen?) {
+        let opacity = profile.effectiveBackgroundOpacity(fallback: fallback)
+        let blur = profile.effectiveBlurIntensity()
+        let wantsTranslucent = opacity < 1.0 || blur > 0
+
+        // When the profile is fully opaque we hide the material so Ghostty's
+        // own background fills the window without any blur cost.
+        isHidden = !wantsTranslucent
+        material = Self.material(forBlurIntensity: blur)
+
+        if profile.effectiveWallpaperTint(), wantsTranslucent {
+            let accent = WallpaperTint.shared.accent(for: screen ?? NSScreen.main)
+            let blended = Self.blend(base: Theme.colors.frame, tint: accent, amount: 0.3)
+            tintLayer.backgroundColor = blended.withAlphaComponent(0.55).cgColor
+            tintLayer.isHidden = false
+        } else {
+            tintLayer.isHidden = true
+        }
+
+        // Keep the BackdropView's own cornerRadius synced with whatever the
+        // container wants for its chrome, so the window silhouette stays
+        // consistent between opaque and translucent modes.
+        if let radius = container.layer?.cornerRadius {
+            layer?.cornerRadius = radius
+        }
+    }
+
+    private static func material(forBlurIntensity intensity: Double) -> NSVisualEffectView.Material {
+        switch intensity {
+        case ..<0.2: return .hudWindow
+        case ..<0.45: return .sidebar
+        case ..<0.7: return .menu
+        default: return .fullScreenUI
+        }
+    }
+
+    private static func blend(base: NSColor, tint: NSColor, amount: CGFloat) -> NSColor {
+        guard let a = base.usingColorSpace(.sRGB),
+              let b = tint.usingColorSpace(.sRGB) else { return base }
+        let inv = 1 - amount
+        return NSColor(
+            srgbRed: a.redComponent * inv + b.redComponent * amount,
+            green: a.greenComponent * inv + b.greenComponent * amount,
+            blue: a.blueComponent * inv + b.blueComponent * amount,
+            alpha: a.alphaComponent
+        )
+    }
+}

--- a/Bellith/Views/Preferences/AppearancePane.swift
+++ b/Bellith/Views/Preferences/AppearancePane.swift
@@ -36,13 +36,24 @@ final class AppearancePane: NSView {
     private let padYLabel = SmallLabel("V")
     private var padYField: MiniNumberField!
 
-    private let windowCard = SettingsCard(title: "Window", subtitle: "Opacity and traffic-light behavior")
-    private let opacityLabel = CardRowLabel("Background Opacity")
-    private var opacityTrack: OpacityTrackView!
+    private let windowCard = SettingsCard(title: "Window", subtitle: "Texture and traffic-light behavior")
     private let noiseLabel = CardRowLabel("Noise Grain")
     private var noiseTrack: OpacityTrackView!
     private let trafficLightLabel = CardRowLabel("Auto-hide Traffic Lights")
     private var trafficLightToggle: PrefToggle!
+
+    private let profileCard = SettingsCard(
+        title: "Profile Appearance",
+        subtitle: "Per-profile opacity, blur, and wallpaper tint"
+    )
+    private let profileSelectLabel = CardRowLabel("Active Profile")
+    private let profilePopup = NSPopUpButton()
+    private let opacityLabel = CardRowLabel("Background Opacity")
+    private var opacityTrack: OpacityTrackView!
+    private let blurLabel = CardRowLabel("Blur Intensity")
+    private var blurTrack: OpacityTrackView!
+    private let tintLabel = CardRowLabel("Wallpaper Tint")
+    private var tintToggle: PrefToggle!
 
     private let statusBarCard = SettingsCard(title: "Status Bar", subtitle: "Choose which indicators appear in the lower metadata strip")
     private let statusBarContextLabel = CardRowLabel("Host & Environment")
@@ -141,8 +152,8 @@ final class AppearancePane: NSView {
 
         tabSegment = PrefSegment(labels: ["Sidebar", "Tab Bar"], selected: settings.tabMode == "sidebar" ? 0 : 1) { [weak self] index in
             self?.settings.tabMode = index == 0 ? "sidebar" : "tabbar"
-            if let window = NSApp.windows.first(where: { $0.contentView is TerminalContainerView }),
-               let container = window.contentView as? TerminalContainerView {
+            if let window = NSApp.windows.first(where: { ($0.contentView as? BackdropView) != nil }),
+               let container = (window.contentView as? BackdropView)?.container {
                 container.applyTabMode()
             }
         }
@@ -161,9 +172,6 @@ final class AppearancePane: NSView {
             interfaceCard.addSubview(view)
         }
 
-        opacityTrack = OpacityTrackView(value: settings.backgroundOpacity) { [weak self] value in
-            self?.settings.backgroundOpacity = value
-        }
         noiseTrack = OpacityTrackView(value: settings.noiseIntensity, minValue: 0.0) { [weak self] value in
             self?.settings.noiseIntensity = value
         }
@@ -171,8 +179,41 @@ final class AppearancePane: NSView {
             self?.settings.trafficLightAutoHide = value
         }
         content.addSubview(windowCard)
-        for view: NSView in [opacityLabel, opacityTrack, noiseLabel, noiseTrack, trafficLightLabel, trafficLightToggle] {
+        for view: NSView in [noiseLabel, noiseTrack, trafficLightLabel, trafficLightToggle] {
             windowCard.addSubview(view)
+        }
+
+        profilePopup.font = BellithFont.mono(12, weight: .regular)
+        profilePopup.focusRingType = .none
+        profilePopup.target = self
+        profilePopup.action = #selector(handleProfileChanged)
+        rebuildProfilePopup()
+
+        let activeProfile = settings.activeProfile
+        opacityTrack = OpacityTrackView(
+            value: activeProfile.effectiveBackgroundOpacity(fallback: settings),
+            minValue: 0.0
+        ) { [weak self] value in
+            self?.settings.updateActiveProfile { $0.backgroundOpacity = value }
+        }
+        blurTrack = OpacityTrackView(
+            value: activeProfile.effectiveBlurIntensity(),
+            minValue: 0.0
+        ) { [weak self] value in
+            self?.settings.updateActiveProfile { $0.blurIntensity = value }
+        }
+        tintToggle = PrefToggle(isOn: activeProfile.effectiveWallpaperTint()) { [weak self] value in
+            self?.settings.updateActiveProfile { $0.wallpaperTint = value }
+            WallpaperTint.shared.invalidate()
+        }
+        content.addSubview(profileCard)
+        for view: NSView in [
+            profileSelectLabel, profilePopup,
+            opacityLabel, opacityTrack,
+            blurLabel, blurTrack,
+            tintLabel, tintToggle,
+        ] {
+            profileCard.addSubview(view)
         }
 
         statusBarContextToggle = PrefToggle(isOn: settings.showStatusBarContext) { [weak self] value in
@@ -253,7 +294,13 @@ final class AppearancePane: NSView {
         statusBarSizeToggle.refreshAppearance()
         padXField.setValue(settings.windowPaddingX)
         padYField.setValue(settings.windowPaddingY)
-        opacityTrack.setValue(settings.backgroundOpacity)
+        rebuildProfilePopup()
+        let active = settings.activeProfile
+        opacityTrack.setValue(active.effectiveBackgroundOpacity(fallback: settings))
+        blurTrack.setValue(active.effectiveBlurIntensity())
+        tintToggle.setOn(active.effectiveWallpaperTint())
+        tintToggle.refreshAppearance()
+        profileCard.refresh()
         noiseTrack.setValue(settings.noiseIntensity)
         trafficLightToggle.setOn(settings.trafficLightAutoHide)
         trafficLightToggle.refreshAppearance()
@@ -286,6 +333,29 @@ final class AppearancePane: NSView {
         lightSummaryValue.textColor = Theme.textPrimary
         activeSummaryValue.textColor = Theme.textDisplay
         activeSummaryNote.textColor = Theme.textSecondary
+    }
+
+    private func rebuildProfilePopup() {
+        profilePopup.removeAllItems()
+        let list = settings.profiles
+        for profile in list {
+            profilePopup.addItem(withTitle: profile.name)
+            profilePopup.lastItem?.representedObject = profile.id
+        }
+        let activeID = settings.activeProfileID
+        if let index = list.firstIndex(where: { $0.id == activeID }) {
+            profilePopup.selectItem(at: index)
+        }
+    }
+
+    @objc private func handleProfileChanged() {
+        guard let id = profilePopup.selectedItem?.representedObject as? String else { return }
+        settings.activeProfileID = id
+        let active = settings.activeProfile
+        opacityTrack.setValue(active.effectiveBackgroundOpacity(fallback: settings))
+        blurTrack.setValue(active.effectiveBlurIntensity())
+        tintToggle.setOn(active.effectiveWallpaperTint())
+        tintToggle.refreshAppearance()
     }
 
     private func importThemes() {
@@ -367,18 +437,31 @@ final class AppearancePane: NSView {
         padYField.frame = NSRect(x: controlX + 106, y: ir2 + 6, width: 56, height: 28)
         y += interfaceCardHeight + PreferencesLayout.sectionGap
 
-        let windowCardHeight = windowCard.headerHeight + 3 * PreferencesLayout.rowH + 2 * PreferencesLayout.rowGap + PreferencesLayout.cardPad
+        let windowCardHeight = windowCard.headerHeight + 2 * PreferencesLayout.rowH + PreferencesLayout.rowGap + PreferencesLayout.cardPad
         windowCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardWidth, height: windowCardHeight)
         let wr0 = windowCardHeight - windowCard.headerHeight - PreferencesLayout.rowH
-        opacityLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: wr0, width: labelWidth, height: PreferencesLayout.rowH)
-        opacityTrack.frame = NSRect(x: controlX, y: wr0 + 8, width: controlWidth, height: 24)
+        noiseLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: wr0, width: labelWidth, height: PreferencesLayout.rowH)
+        noiseTrack.frame = NSRect(x: controlX, y: wr0 + 8, width: controlWidth, height: 24)
         let wr1 = wr0 - PreferencesLayout.rowH - PreferencesLayout.rowGap
-        noiseLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: wr1, width: labelWidth, height: PreferencesLayout.rowH)
-        noiseTrack.frame = NSRect(x: controlX, y: wr1 + 8, width: controlWidth, height: 24)
-        let wr2 = wr1 - PreferencesLayout.rowH - PreferencesLayout.rowGap
-        trafficLightLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: wr2, width: toggleLabelWidth, height: PreferencesLayout.rowH)
-        trafficLightToggle.frame = PreferencesLayout.trailingToggleFrame(cardWidth: cardWidth, rowY: wr2)
+        trafficLightLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: wr1, width: toggleLabelWidth, height: PreferencesLayout.rowH)
+        trafficLightToggle.frame = PreferencesLayout.trailingToggleFrame(cardWidth: cardWidth, rowY: wr1)
         y += windowCardHeight + PreferencesLayout.sectionGap
+
+        let profileCardHeight = profileCard.headerHeight + 4 * PreferencesLayout.rowH + 3 * PreferencesLayout.rowGap + PreferencesLayout.cardPad
+        profileCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardWidth, height: profileCardHeight)
+        let pr0 = profileCardHeight - profileCard.headerHeight - PreferencesLayout.rowH
+        profileSelectLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: pr0, width: labelWidth, height: PreferencesLayout.rowH)
+        profilePopup.frame = NSRect(x: controlX, y: pr0 + 4, width: min(220, controlWidth), height: 28)
+        let pr1 = pr0 - PreferencesLayout.rowH - PreferencesLayout.rowGap
+        opacityLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: pr1, width: labelWidth, height: PreferencesLayout.rowH)
+        opacityTrack.frame = NSRect(x: controlX, y: pr1 + 8, width: controlWidth, height: 24)
+        let pr2 = pr1 - PreferencesLayout.rowH - PreferencesLayout.rowGap
+        blurLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: pr2, width: labelWidth, height: PreferencesLayout.rowH)
+        blurTrack.frame = NSRect(x: controlX, y: pr2 + 8, width: controlWidth, height: 24)
+        let pr3 = pr2 - PreferencesLayout.rowH - PreferencesLayout.rowGap
+        tintLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: pr3, width: toggleLabelWidth, height: PreferencesLayout.rowH)
+        tintToggle.frame = PreferencesLayout.trailingToggleFrame(cardWidth: cardWidth, rowY: pr3)
+        y += profileCardHeight + PreferencesLayout.sectionGap
 
         let statusBarCardHeight = statusBarCard.headerHeight + 7 * PreferencesLayout.rowH + 6 * PreferencesLayout.rowGap + PreferencesLayout.cardPad
         statusBarCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardWidth, height: statusBarCardHeight)

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -155,14 +155,16 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         NotificationCenter.default.publisher(for: BellithSettings.didChangeNotification)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                self?.applyFrameColor()
-                self?.statusBar.refreshTheme()
-                self?.titleBar.refreshTheme()
-                if let self {
-                    self.handleStatusBarVisibilityChange(self.shouldShowStatusBar)
+                guard let self else { return }
+                self.applyFrameColor()
+                self.statusBar.refreshTheme()
+                self.titleBar.refreshTheme()
+                self.handleStatusBarVisibilityChange(self.shouldShowStatusBar)
+                for tab in self.tabs {
+                    self.applyChrome(to: tab.rootView)
                 }
-                self?.needsLayout = true
-                self?.reloadConfig()
+                self.needsLayout = true
+                self.reloadConfig()
             }
             .store(in: &observationCancellables)
 
@@ -251,7 +253,9 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
     }
 
     private func applyChromeTheme() {
-        contentBackdropLayer.backgroundColor = Theme.surface.cgColor
+        contentBackdropLayer.backgroundColor = activeProfileIsTranslucent
+            ? NSColor.clear.cgColor
+            : Theme.surface.cgColor
         contentBackdropLayer.shadowColor = NSColor.clear.cgColor
         contentBackdropLayer.shadowOpacity = 0
         contentBackdropLayer.shadowRadius = 0
@@ -285,7 +289,15 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         root.layer?.masksToBounds = true
         root.layer?.borderWidth = 0
         root.layer?.borderColor = NSColor.clear.cgColor
-        root.layer?.backgroundColor = Theme.surface.cgColor
+        root.layer?.backgroundColor = activeProfileIsTranslucent
+            ? NSColor.clear.cgColor
+            : Theme.surface.cgColor
+    }
+
+    private var activeProfileIsTranslucent: Bool {
+        let profile = dependencies.settings.activeProfile
+        return profile.effectiveBackgroundOpacity(fallback: dependencies.settings) < 1.0
+            || profile.effectiveBlurIntensity() > 0
     }
 
     private func updateChromeFrames(animated: Bool, sidebarWidth: CGFloat? = nil, statusBarVisible: Bool? = nil) {
@@ -1923,7 +1935,9 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
     // MARK: - Theme
 
     private func applyFrameColor() {
-        layer?.backgroundColor = Theme.colors.frame.cgColor
+        layer?.backgroundColor = activeProfileIsTranslucent
+            ? NSColor.clear.cgColor
+            : Theme.colors.frame.cgColor
         // Slider 0–1 maps to 0–0.08 (dark) or 0–0.12 (light) actual opacity
         let maxOpacity: Double = Theme.colors.isLight ? 0.12 : 0.08
         noiseLayer.opacity = Float(dependencies.settings.noiseIntensity * maxOpacity)

--- a/Bellith/Views/TerminalWindow.swift
+++ b/Bellith/Views/TerminalWindow.swift
@@ -29,6 +29,8 @@ final class TerminalWindow: NSWindow {
     private var trafficLightsVisible = true
     private var trafficLightDisplayMode: TrafficLightDisplayMode = .automatic
     private let settings: BellithSettings
+    private var settingsObserver: NSObjectProtocol?
+    private var wallpaperObserver: NSObjectProtocol?
 
     override init(
         contentRect: NSRect,
@@ -73,11 +75,11 @@ final class TerminalWindow: NSWindow {
 
         applyThemeBackground()
         applyThemeAppearance()
-        isOpaque = true
         hasShadow = true
         contentView?.wantsLayer = true
         contentView?.layer?.cornerRadius = Theme.radiusWindow + 4
         contentView?.layer?.masksToBounds = true
+        applyProfileAppearance()
 
         // Clear titlebar backgrounds
         if let titlebarContainer = standardWindowButton(.closeButton)?.superview?.superview {
@@ -98,15 +100,50 @@ final class TerminalWindow: NSWindow {
         ) { [weak self] _ in
             self?.applyThemeBackground()
             self?.applyThemeAppearance()
+            self?.applyProfileAppearance()
             self?.positionTrafficLights()
+        }
+
+        settingsObserver = NotificationCenter.default.addObserver(
+            forName: BellithSettings.didChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.applyProfileAppearance()
+        }
+
+        wallpaperObserver = NotificationCenter.default.addObserver(
+            forName: WallpaperTint.didChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.applyProfileAppearance()
         }
     }
 
     private func applyThemeBackground() {
-        backgroundColor = Theme.colors.frame
-        contentView?.layer?.backgroundColor = Theme.colors.frame.cgColor
         contentView?.layer?.borderWidth = 0
         contentView?.layer?.borderColor = NSColor.clear.cgColor
+        // The visible frame color is resolved in applyProfileAppearance so
+        // translucent profiles can bypass the opaque fill.
+    }
+
+    /// Syncs the window chrome to the active profile. Ghostty renders the
+    /// terminal background with `background-opacity`, so we just toggle the
+    /// window between opaque and clear backing. The `BackdropView` that
+    /// wraps the terminal container is always present — it provides the
+    /// material that shows through Ghostty's alpha.
+    private func applyProfileAppearance() {
+        let profile = settings.activeProfile
+        let opacity = profile.effectiveBackgroundOpacity(fallback: settings)
+        let blur = profile.effectiveBlurIntensity()
+        let wantsTranslucent = opacity < 1.0 || blur > 0
+
+        alphaValue = 1.0
+        isOpaque = !wantsTranslucent
+        backgroundColor = wantsTranslucent ? .clear : Theme.colors.frame
+
+        if let backdrop = contentView as? BackdropView {
+            backdrop.apply(profile: profile, fallback: settings, screen: screen)
+        }
+
+        invalidateShadow()
     }
 
     private func applyThemeAppearance() {
@@ -115,6 +152,8 @@ final class TerminalWindow: NSWindow {
 
     deinit {
         if let themeObserver { NotificationCenter.default.removeObserver(themeObserver) }
+        if let settingsObserver { NotificationCenter.default.removeObserver(settingsObserver) }
+        if let wallpaperObserver { NotificationCenter.default.removeObserver(wallpaperObserver) }
     }
 
     // MARK: - Traffic Light Auto-Hide
@@ -192,6 +231,7 @@ final class TerminalWindow: NSWindow {
         super.makeKeyAndOrderFront(sender)
         positionTrafficLights()
         setupTrafficLightTracking()
+        applyProfileAppearance()
     }
 
     private var lastTrackingHeight: CGFloat = 0

--- a/BellithTests/BellithSettingsTests.swift
+++ b/BellithTests/BellithSettingsTests.swift
@@ -217,6 +217,57 @@ final class BellithSettingsTests: XCTestCase {
         XCTAssertEqual(settings.backgroundOpacity, 0.8, accuracy: 0.001)
     }
 
+    // MARK: - Profile Appearance
+
+    func testDefaultProfileExistsWithMigratedOpacity() {
+        // Setup seeds a fresh suite; backgroundOpacity stays at 1.0 and the
+        // default profile inherits it through the migration pass.
+        XCTAssertEqual(settings.profiles.count, 1)
+        XCTAssertEqual(settings.activeProfileID, TerminalProfile.defaultID)
+        XCTAssertEqual(
+            settings.activeProfile.effectiveBackgroundOpacity(fallback: settings),
+            1.0,
+            accuracy: 0.001
+        )
+    }
+
+    func testUpdateActiveProfilePersistsOpacityAndBlur() {
+        settings.updateActiveProfile {
+            $0.backgroundOpacity = 0.65
+            $0.blurIntensity = 0.4
+            $0.wallpaperTint = true
+        }
+        let reloaded = BellithSettings(defaults: defaults, settingsFileURL: settingsFileURL)
+        let profile = reloaded.activeProfile
+        XCTAssertEqual(profile.effectiveBackgroundOpacity(fallback: reloaded), 0.65, accuracy: 0.001)
+        XCTAssertEqual(profile.effectiveBlurIntensity(), 0.4, accuracy: 0.001)
+        XCTAssertTrue(profile.effectiveWallpaperTint())
+    }
+
+    func testActiveProfileIDFallsBackToDefaultWhenMissing() {
+        settings.activeProfileID = "does-not-exist"
+        XCTAssertEqual(settings.activeProfileID, TerminalProfile.defaultID)
+    }
+
+    func testAddingSecondProfileAndSwitching() {
+        var list = settings.profiles
+        list.append(TerminalProfile(
+            id: "focus",
+            name: "Focus",
+            backgroundOpacity: 0.3,
+            blurIntensity: 0.8,
+            wallpaperTint: true
+        ))
+        settings.profiles = list
+        settings.activeProfileID = "focus"
+        XCTAssertEqual(settings.activeProfile.id, "focus")
+        XCTAssertEqual(
+            settings.activeProfile.effectiveBackgroundOpacity(fallback: settings),
+            0.3,
+            accuracy: 0.001
+        )
+    }
+
     func testBooleanSettingsRoundtrip() {
         settings.mouseHideWhileTyping = false
         XCTAssertFalse(settings.mouseHideWhileTyping)

--- a/BellithTests/TerminalConfigTests.swift
+++ b/BellithTests/TerminalConfigTests.swift
@@ -184,13 +184,28 @@ final class TerminalConfigTests: XCTestCase {
     }
 
     func testGeneratedConfigParsesWithoutDiagnostics() {
-        let config = TerminalConfig()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalConfigTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let config = TerminalConfig(settings: settings, configurationDirectory: directory)
         guard let rawConfig = config.config else {
             return XCTFail("Expected a Ghostty config object")
         }
 
         let diagnosticsCount = ghostty_config_diagnostics_count(rawConfig)
-        XCTAssertEqual(diagnosticsCount, 0, "Expected generated config to parse cleanly")
+        var messages: [String] = []
+        for i in 0..<diagnosticsCount {
+            let diag = ghostty_config_get_diagnostic(rawConfig, i)
+            if let ptr = diag.message {
+                messages.append(String(cString: ptr))
+            }
+        }
+        XCTAssertEqual(
+            diagnosticsCount,
+            0,
+            "Expected generated config to parse cleanly. Diagnostics: \(messages)"
+        )
     }
 
     func testInitializationCapturesConfigWriteFailures() throws {


### PR DESCRIPTION
Closes #54.

## Summary
- `TerminalProfile` gains `backgroundOpacity`, `blurIntensity`, and `wallpaperTint` (the legacy global `backgroundOpacity` migrates onto the default profile).
- New `BackdropView` (an `NSVisualEffectView` subclass) becomes the window's content view and hosts the `TerminalContainerView`, so translucent profiles have a blurred material behind Ghostty's alpha pixels instead of the raw desktop.
- Blur intensity forwards to Ghostty's native `background-blur-radius` and picks a heavier `NSVisualEffectView.Material` on the backdrop.
- `WallpaperTint` samples the desktop wallpaper and produces a muted accent used to tint the backdrop when the profile opts in; the sample refreshes on space-change notifications.
- Appearance pane gains a "Profile Appearance" card with a profile picker and per-profile opacity/blur sliders + tint toggle. All changes apply live via the existing settings-change notification path (no relaunch needed).
- Terminal card layers (`contentBackdropLayer`, tab root, container frame) go clear when the active profile is translucent so the material shows through.

## Test plan
- [x] `make build`
- [x] Unit tests for profile persistence, active-profile switching, and the legacy opacity migration (`BellithSettingsTests`)
- [x] `TerminalConfigTests` updated to inject hermetic settings (surfaces a pre-existing theme-lookup diagnostic that is not introduced by this PR)
- [ ] Manual: toggle Default profile opacity between 1.0 and 0.4, confirm terminal stays legible and the blur material is visible behind it
- [ ] Manual: drag the blur slider from 0 → 1 and verify Ghostty's native blur kicks in
- [ ] Manual: enable wallpaper tint and switch desktop spaces; tint should refresh
- [ ] Manual: add a second profile, switch between them via the new picker, confirm the live window updates without relaunch

## Notes
- Per-window, not per-split: Ghostty's config is loaded per-app, so a single active profile drives all windows. Richer profile management (rename/delete/duplicate) is intentionally deferred.
- `TerminalConfigTests.testGeneratedConfigParsesWithoutDiagnostics` was pre-existing flaky on master (theme-lookup diagnostic); the test is now hermetic and prints diagnostic messages, but the underlying issue is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)