### PR TITLE
feat(workspaces): named workspaces with saved layouts

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		2BC36AC2F4C1DD3823B68CA5 /* SSHSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9591082C7912641248227C8 /* SSHSessionDetector.swift */; };
 		2D7878CD0D5FB019A68AAA07 /* SessionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08540536C434953689D04D /* SessionStateTests.swift */; };
 		37CF1D9BB62D1BB55D63B0D0 /* TerminalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5966D19E6F059737E8B875 /* TerminalContext.swift */; };
+		3A1174A2E3493312D0C43F2A /* WorkspaceDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B639E55908BD9DDCD969BFE /* WorkspaceDefinition.swift */; };
 		3A8626193F1471C659C10A4A /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF3103FA440F936419F4846 /* BlurView.swift */; };
 		3AA2DA3E813BBA3E1B8CF1B9 /* SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AD21D2101DAB69E92DFB59 /* SessionState.swift */; };
 		3F067DBCA20A52FB30980DA2 /* SSHProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AC775F3A6A91CF3FE4CDAB /* SSHProfileStoreTests.swift */; };
@@ -93,6 +94,7 @@
 		DDDD63014E36721A941C97E4 /* TerminalProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772785F1920803E52A7235C8 /* TerminalProfile.swift */; };
 		E450123DFE8F0EBAD8050A69 /* BackdropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27A4F297624101EA6EA1124 /* BackdropView.swift */; };
 		E90F976F4D03F92405690751 /* GitHubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419904C2F6EF539F340C4054 /* GitHubService.swift */; };
+		EC22286AF20F181A9F1AB072 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAA686EB03918C02A471CF0 /* WorkspaceStore.swift */; };
 		F0688F637632B59A01825393 /* TerminalContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72367912169712669D03FD67 /* TerminalContainerView.swift */; };
 		F26474311EB82215B71E0CE0 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC69484808B270DA784451B1 /* SearchBarView.swift */; };
 		F565B2256404B0E12F1759C5 /* AIToolSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7761C9EFFC090C4726758B71 /* AIToolSessionDetector.swift */; };
@@ -127,6 +129,7 @@
 		1055D889FA5B87C7B010166B /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		17F1A89752C176F1F7719413 /* ShortcutDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutDefinitions.swift; sourceTree = "<group>"; };
 		185BCA9A77D1E03020788D4D /* PreferencesComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesComponents.swift; sourceTree = "<group>"; };
+		1AAA686EB03918C02A471CF0 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		1B08540536C434953689D04D /* SessionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStateTests.swift; sourceTree = "<group>"; };
 		1DDFFEF2B5A4E5BE5E1A7669 /* LocalSessionLaunchBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSessionLaunchBuilderTests.swift; sourceTree = "<group>"; };
 		1E2025F109793353C35658F9 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = Frameworks/GhosttyKit.xcframework; sourceTree = "<group>"; };
@@ -147,6 +150,7 @@
 		4FD22E965C6F1A921DC3AFFA /* BellithSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellithSettingsTests.swift; sourceTree = "<group>"; };
 		52E9612F02A1A65DFA8CA240 /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
 		595A49A926D6775A52202AAD /* ITermColorsImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ITermColorsImporter.swift; sourceTree = "<group>"; };
+		5B639E55908BD9DDCD969BFE /* WorkspaceDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDefinition.swift; sourceTree = "<group>"; };
 		6246E34985DFC9EC1E6DB555 /* bellith-cli */ = {isa = PBXFileReference; includeInIndex = 0; path = "bellith-cli"; sourceTree = BUILT_PRODUCTS_DIR; };
 		64B019E37CE2B850357E2B7E /* TerminalSurfaceViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceViewTests.swift; sourceTree = "<group>"; };
 		6651B379E02056CE70DC9C84 /* BellithBranding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellithBranding.swift; sourceTree = "<group>"; };
@@ -393,6 +397,7 @@
 				359237193DE4C0621F16BDD8 /* SSHProfile.swift */,
 				FC5966D19E6F059737E8B875 /* TerminalContext.swift */,
 				772785F1920803E52A7235C8 /* TerminalProfile.swift */,
+				5B639E55908BD9DDCD969BFE /* WorkspaceDefinition.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -412,6 +417,7 @@
 				707A2AF28DE5D2F8EA639BFB /* TerminalSessionCoordinator.swift */,
 				EE6157DFCE204C3ADC26FA72 /* ToolActivityMonitor.swift */,
 				FCD317F56432F400BA1567BB /* WallpaperTint.swift */,
+				1AAA686EB03918C02A471CF0 /* WorkspaceStore.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -692,6 +698,8 @@
 				55B5329D0C164FDCBEE88A5D /* ToolActivityMonitor.swift in Sources */,
 				DAF1FF85E2B99E346EE83564 /* ToolActivityPanel.swift in Sources */,
 				3FE2152821D44C82B14D0338 /* WallpaperTint.swift in Sources */,
+				3A1174A2E3493312D0C43F2A /* WorkspaceDefinition.swift in Sources */,
+				EC22286AF20F181A9F1AB072 /* WorkspaceStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bellith/App/AppDelegate.swift
+++ b/Bellith/App/AppDelegate.swift
@@ -24,6 +24,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var terminalConfigFailureObserver: NSObjectProtocol?
     private var settingsObserver: NSObjectProtocol?
     private var themeMenu = NSMenu(title: "Theme")
+    private var workspacesMenu = NSMenu(title: "Workspaces")
+    private var workspaceStoreObserver: NSObjectProtocol?
 
     private struct WindowEntry {
         let window: TerminalWindow
@@ -131,6 +133,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             createWindow()
         }
         setupMenus()
+
+        workspaceStoreObserver = NotificationCenter.default.addObserver(
+            forName: WorkspaceStore.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.rebuildWorkspacesMenu()
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -173,6 +183,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         if let obs = settingsObserver {
             NotificationCenter.default.removeObserver(obs)
             settingsObserver = nil
+        }
+        if let obs = workspaceStoreObserver {
+            NotificationCenter.default.removeObserver(obs)
+            workspaceStoreObserver = nil
         }
 
         // Tear down all windows
@@ -362,6 +376,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             shellMenu.addItem(.separator())
             shellMenu.addItem(configuredMenuItem(title: "Close Pane", action: #selector(handleClosePane), shortcutID: "closePane"))
         }
+        shellMenu.addItem(.separator())
+        rebuildWorkspacesMenu()
+        let workspacesItem = NSMenuItem(title: "Workspaces", action: nil, keyEquivalent: "")
+        workspacesItem.submenu = workspacesMenu
+        shellMenu.addItem(workspacesItem)
+        shellMenu.addItem(.separator())
         shellMenu.addItem(configuredMenuItem(title: "Close Tab", action: #selector(handleCloseTab), shortcutID: "closeTab"))
         shellMenu.addItem(configuredMenuItem(title: "Close Window", action: #selector(handleCloseWindow)))
         let shellMenuItem = NSMenuItem()
@@ -479,7 +499,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         item.keyEquivalentModifierMask = shortcut.modifierFlags
     }
 
+    private func rebuildWorkspacesMenu() {
+        workspacesMenu.removeAllItems()
+        let workspaces = WorkspaceStore.shared.workspaces
+        if workspaces.isEmpty {
+            let empty = NSMenuItem(title: "No Saved Workspaces", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            workspacesMenu.addItem(empty)
+        } else {
+            for workspace in workspaces {
+                let item = NSMenuItem(
+                    title: workspace.name,
+                    action: #selector(handleOpenWorkspace(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = workspace.id
+                workspacesMenu.addItem(item)
+            }
+        }
+        workspacesMenu.addItem(.separator())
+        let saveItem = NSMenuItem(
+            title: "Save Current as Workspace…",
+            action: #selector(handleSaveWorkspace),
+            keyEquivalent: ""
+        )
+        saveItem.target = self
+        workspacesMenu.addItem(saveItem)
+    }
+
     // MARK: - Menu Actions
+
+    @objc private func handleOpenWorkspace(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? UUID,
+              let workspace = WorkspaceStore.shared.workspace(id: id) else { return }
+        if let container = activeEntry?.container {
+            container.restoreSession(workspace.session)
+        } else {
+            createWindow(session: workspace.session)
+        }
+    }
+
+    @objc private func handleSaveWorkspace() {
+        activeEntry?.container.promptSaveWorkspace()
+    }
 
     @objc private func handleCopy() { activeEntry?.container.copySelection() }
     @objc private func handlePaste() { activeEntry?.container.pasteClipboard() }

--- a/Bellith/Models/CommandRegistry.swift
+++ b/Bellith/Models/CommandRegistry.swift
@@ -43,24 +43,27 @@ final class CommandRegistry {
     private var commandsByID: [String: CommandPlugin] = [:]
     private let smartPanelRegistry: SmartPanelRegistry
     private let sshProfileStore: SSHProfileStore
+    private let workspaceStore: WorkspaceStore
     private let preferencesWindowController: PreferencesWindowController
     private let settings: BellithSettings
 
     init(
         smartPanelRegistry: SmartPanelRegistry = .shared,
         sshProfileStore: SSHProfileStore = .shared,
+        workspaceStore: WorkspaceStore = .shared,
         preferencesWindowController: PreferencesWindowController = .shared,
         settings: BellithSettings = .shared
     ) {
         self.smartPanelRegistry = smartPanelRegistry
         self.sshProfileStore = sshProfileStore
+        self.workspaceStore = workspaceStore
         self.preferencesWindowController = preferencesWindowController
         self.settings = settings
         registerBuiltIns()
     }
 
     var allCommands: [CommandPlugin] {
-        orderedCommandIDs.compactMap { commandsByID[$0] } + smartPanelCommands + sshProfileCommands
+        orderedCommandIDs.compactMap { commandsByID[$0] } + smartPanelCommands + sshProfileCommands + workspaceCommands
     }
 
     func command(matching text: String) -> CommandPlugin? {
@@ -101,6 +104,21 @@ final class CommandRegistry {
                 aliases: [profile.host, profile.destination, profile.displayName]
             ) { container, _ in
                 container.connectSSHProfile(id: profile.id)
+                return true
+            }
+        }
+    }
+
+    private var workspaceCommands: [CommandPlugin] {
+        workspaceStore.workspaces.map { workspace in
+            CommandPlugin(
+                id: "workspace-\(workspace.id.uuidString)",
+                title: "Open Workspace: \(workspace.name)",
+                description: "Restore the \"\(workspace.name)\" workspace layout",
+                iconName: "square.grid.2x2",
+                aliases: [workspace.name]
+            ) { container, _ in
+                container.restoreSession(workspace.session)
                 return true
             }
         }
@@ -509,6 +527,28 @@ final class CommandRegistry {
                 process.standardError = FileHandle.nullDevice
                 try? process.run()
             }
+            return true
+        })
+
+        register(CommandPlugin(
+            id: "saveWorkspace",
+            title: "Save Workspace",
+            description: "Save current layout as a named workspace",
+            iconName: "square.and.arrow.down",
+            aliases: ["save workspace", "workspace save", "create workspace"]
+        ) { container, _ in
+            container.promptSaveWorkspace()
+            return true
+        })
+
+        register(CommandPlugin(
+            id: "deleteWorkspace",
+            title: "Delete Workspace",
+            description: "Delete a saved workspace",
+            iconName: "trash",
+            aliases: ["delete workspace", "remove workspace", "workspace delete"]
+        ) { container, _ in
+            container.promptDeleteWorkspace()
             return true
         })
     }

--- a/Bellith/Models/WorkspaceDefinition.swift
+++ b/Bellith/Models/WorkspaceDefinition.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct WorkspaceDefinition: Codable, Identifiable {
+    let id: UUID
+    var name: String
+    var session: SessionState
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(name: String, session: SessionState) {
+        self.id = UUID()
+        self.name = name
+        self.session = session
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+}

--- a/Bellith/Services/WorkspaceStore.swift
+++ b/Bellith/Services/WorkspaceStore.swift
@@ -1,0 +1,77 @@
+import Foundation
+import os
+
+final class WorkspaceStore {
+    static let shared = WorkspaceStore()
+    static let didChangeNotification = Notification.Name("WorkspaceStoreDidChange")
+
+    private let defaults: UserDefaults
+    private let storageKey = "namedWorkspaces"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var workspaces: [WorkspaceDefinition] {
+        loadWorkspaces()
+    }
+
+    func workspace(id: UUID) -> WorkspaceDefinition? {
+        workspaces.first { $0.id == id }
+    }
+
+    func workspace(named name: String) -> WorkspaceDefinition? {
+        let lower = name.lowercased()
+        return workspaces.first { $0.name.lowercased() == lower }
+    }
+
+    func save(_ workspace: WorkspaceDefinition) {
+        var all = workspaces
+        if let index = all.firstIndex(where: { $0.id == workspace.id }) {
+            all[index] = workspace
+        } else {
+            all.append(workspace)
+        }
+        persist(all)
+    }
+
+    func delete(id: UUID) {
+        persist(workspaces.filter { $0.id != id })
+    }
+
+    func rename(id: UUID, to newName: String) {
+        var all = workspaces
+        guard let index = all.firstIndex(where: { $0.id == id }) else { return }
+        all[index].name = newName
+        all[index].updatedAt = Date()
+        persist(all)
+    }
+
+    func updateSession(id: UUID, session: SessionState) {
+        var all = workspaces
+        guard let index = all.firstIndex(where: { $0.id == id }) else { return }
+        all[index].session = session
+        all[index].updatedAt = Date()
+        persist(all)
+    }
+
+    private func persist(_ workspaces: [WorkspaceDefinition]) {
+        do {
+            let data = try JSONEncoder().encode(workspaces)
+            defaults.set(data, forKey: storageKey)
+            NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
+        } catch {
+            Logger.config.error("Failed to persist workspaces: \(error.localizedDescription)")
+        }
+    }
+
+    private func loadWorkspaces() -> [WorkspaceDefinition] {
+        guard let data = defaults.data(forKey: storageKey) else { return [] }
+        do {
+            return try JSONDecoder().decode([WorkspaceDefinition].self, from: data)
+        } catch {
+            Logger.config.error("Failed to decode workspaces: \(error.localizedDescription)")
+            return []
+        }
+    }
+}

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -2183,6 +2183,70 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         }
     }
 
+    // MARK: - Workspaces
+
+    func promptSaveWorkspace() {
+        let alert = NSAlert()
+        alert.messageText = "Save Workspace"
+        alert.informativeText = "Enter a name for this workspace layout:"
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 24))
+        input.placeholderString = "Workspace name"
+        alert.accessoryView = input
+        alert.window.initialFirstResponder = input
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let name = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+
+        let session = saveSession()
+        let store = WorkspaceStore.shared
+
+        if let existing = store.workspace(named: name) {
+            let confirm = NSAlert()
+            confirm.messageText = "Workspace Exists"
+            confirm.informativeText = "A workspace named \"\(name)\" already exists. Replace it?"
+            confirm.addButton(withTitle: "Replace")
+            confirm.addButton(withTitle: "Cancel")
+            guard confirm.runModal() == .alertFirstButtonReturn else { return }
+            store.updateSession(id: existing.id, session: session)
+        } else {
+            store.save(WorkspaceDefinition(name: name, session: session))
+        }
+    }
+
+    func promptDeleteWorkspace() {
+        let store = WorkspaceStore.shared
+        let workspaces = store.workspaces
+        guard !workspaces.isEmpty else {
+            let alert = NSAlert()
+            alert.messageText = "No Workspaces"
+            alert.informativeText = "There are no saved workspaces to delete."
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+
+        let alert = NSAlert()
+        alert.messageText = "Delete Workspace"
+        alert.informativeText = "Select a workspace to delete:"
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+
+        let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 260, height: 24), pullsDown: false)
+        for ws in workspaces {
+            popup.addItem(withTitle: ws.name)
+        }
+        alert.accessoryView = popup
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let selectedIndex = popup.indexOfSelectedItem
+        guard selectedIndex >= 0, selectedIndex < workspaces.count else { return }
+        store.delete(id: workspaces[selectedIndex].id)
+    }
+
     // MARK: - Surface Factory
 
     /// Centralized surface creation — wires up all callbacks (onClose, onTextInserted).


### PR DESCRIPTION
## Summary
- Adds named workspaces that capture tab layout, split tree, per-pane CWD, env vars, and SSH profile references
- Create/update/delete workspaces via command palette ("Save Workspace", "Delete Workspace") or File > Workspaces menu
- Opening a workspace restores all tabs/splits/CWDs using the existing `SessionState` infrastructure
- Workspace commands appear in the command palette with fuzzy search

## New files
- `Bellith/Models/WorkspaceDefinition.swift` — `Codable` model wrapping `SessionState` with name/timestamps
- `Bellith/Services/WorkspaceStore.swift` — CRUD persistence via `UserDefaults` (follows `SSHProfileStore` pattern)

## Modified files
- `CommandRegistry.swift` — registers "Save Workspace" / "Delete Workspace" commands + dynamic "Open Workspace: {name}" entries
- `TerminalContainerView.swift` — `promptSaveWorkspace()` and `promptDeleteWorkspace()` with native `NSAlert` dialogs
- `AppDelegate.swift` — File > Workspaces submenu that auto-refreshes on store changes

## Test plan
- [ ] Open command palette, type "save workspace", enter a name — verify it persists
- [ ] Open command palette, type workspace name — verify layout restores correctly (tabs, CWDs, SSH profiles)
- [ ] Save a workspace with the same name — verify replace confirmation dialog
- [ ] Delete a workspace via command palette
- [ ] Verify File > Workspaces menu lists saved workspaces and updates dynamically
- [ ] Quit and relaunch — verify workspaces survive across app restarts

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)