### PR TITLE
feat(ssh): add mosh transport for saved profiles

### DIFF
--- a/Bellith/Models/SSHProfile.swift
+++ b/Bellith/Models/SSHProfile.swift
@@ -17,11 +17,26 @@ enum SSHSessionBootstrap: String, Codable, CaseIterable {
     }
 }
 
+enum SSHTransport: String, Codable, CaseIterable {
+    case ssh
+    case mosh
+
+    var title: String {
+        switch self {
+        case .ssh:
+            return "SSH"
+        case .mosh:
+            return "Mosh"
+        }
+    }
+}
+
 struct SSHProfile: Codable, Equatable, Identifiable {
     let id: UUID
     var name: String
     var host: String
     var user: String
+    var transport: SSHTransport
     var port: Int
     var identityPath: String
     var proxyJump: String
@@ -38,6 +53,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
         name: String = "New Host",
         host: String = "",
         user: String = "",
+        transport: SSHTransport = .ssh,
         port: Int = 22,
         identityPath: String = "",
         proxyJump: String = "",
@@ -67,6 +83,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
         self.name = name
         self.host = host
         self.user = user
+        self.transport = transport
         self.port = port
         self.identityPath = identityPath
         self.proxyJump = proxyJump
@@ -117,6 +134,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
             name: displayName,
             host: trimmedHost,
             user: trimmedUser,
+            transport: transport,
             port: max(1, min(65_535, port)),
             identityPath: trimmedIdentityPath,
             proxyJump: trimmedProxyJump,
@@ -150,6 +168,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
         case name
         case host
         case user
+        case transport
         case port
         case identityPath
         case proxyJump
@@ -181,6 +200,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
             name: try container.decodeIfPresent(String.self, forKey: .name) ?? "New Host",
             host: try container.decodeIfPresent(String.self, forKey: .host) ?? "",
             user: try container.decodeIfPresent(String.self, forKey: .user) ?? "",
+            transport: try container.decodeIfPresent(SSHTransport.self, forKey: .transport) ?? .ssh,
             port: try container.decodeIfPresent(Int.self, forKey: .port) ?? 22,
             identityPath: try container.decodeIfPresent(String.self, forKey: .identityPath) ?? "",
             proxyJump: try container.decodeIfPresent(String.self, forKey: .proxyJump) ?? "",
@@ -200,6 +220,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
         try container.encode(name, forKey: .name)
         try container.encode(host, forKey: .host)
         try container.encode(user, forKey: .user)
+        try container.encode(transport, forKey: .transport)
         try container.encode(port, forKey: .port)
         try container.encode(identityPath, forKey: .identityPath)
         try container.encode(proxyJump, forKey: .proxyJump)

--- a/Bellith/Services/SSHLaunchBuilder.swift
+++ b/Bellith/Services/SSHLaunchBuilder.swift
@@ -3,6 +3,75 @@ import Foundation
 enum SSHLaunchBuilder {
     static func command(for profile: SSHProfile) -> String {
         let profile = profile.sanitized()
+
+        switch profile.transport {
+        case .ssh:
+            return sshCommand(for: profile)
+        case .mosh:
+            return moshCommand(for: profile)
+        }
+    }
+
+    private static func sshCommand(for profile: SSHProfile, remoteCommandOverride: String? = nil) -> String {
+        var parts = sshTransportParts(for: profile)
+        parts.append(shellQuoted(profile.destination))
+
+        if let remoteCommand = remoteCommandOverride ?? remoteCommand(for: profile) {
+            parts.append("--")
+            parts.append("sh")
+            parts.append("-lc")
+            parts.append(shellQuoted(remoteCommand))
+        }
+
+        return parts.joined(separator: " ")
+    }
+
+    private static func moshCommand(for profile: SSHProfile) -> String {
+        let fallbackSSHCommand = sshCommand(for: profile)
+        let remoteCheckCommand = sshCommand(
+            for: profile,
+            remoteCommandOverride: "command -v mosh-server >/dev/null 2>&1"
+        )
+        let remoteLaunchCommand = moshLaunchCommand(for: profile)
+        let localFallbackMessage = "Bellith: mosh is not installed locally. Falling back to SSH."
+        let remoteFallbackMessage = "Bellith: mosh-server is unavailable on \(profile.destination). Falling back to SSH."
+
+        return """
+        if command -v mosh >/dev/null 2>&1; then
+          if \(remoteCheckCommand); then
+            \(remoteLaunchCommand)
+          else
+            printf '%s\\n' \(shellQuoted(remoteFallbackMessage))
+            \(fallbackSSHCommand)
+          fi
+        else
+          printf '%s\\n' \(shellQuoted(localFallbackMessage))
+          \(fallbackSSHCommand)
+        fi
+        """
+    }
+
+    private static func moshLaunchCommand(for profile: SSHProfile) -> String {
+        var parts = [
+            "mosh",
+            "--ssh=\(shellQuoted(sshTransportCommand(for: profile)))",
+            shellQuoted(profile.destination),
+        ]
+
+        if let remoteCommand = remoteCommand(for: profile) {
+            parts.append("sh")
+            parts.append("-lc")
+            parts.append(shellQuoted(remoteCommand))
+        }
+
+        return parts.joined(separator: " ")
+    }
+
+    private static func sshTransportCommand(for profile: SSHProfile) -> String {
+        sshTransportParts(for: profile).joined(separator: " ")
+    }
+
+    private static func sshTransportParts(for profile: SSHProfile) -> [String] {
         var parts = ["ssh"]
 
         if profile.port != 22 {
@@ -20,16 +89,7 @@ enum SSHLaunchBuilder {
             parts.append(shellQuoted(profile.proxyJump))
         }
 
-        parts.append(shellQuoted(profile.destination))
-
-        if let remoteCommand = remoteCommand(for: profile) {
-            parts.append("--")
-            parts.append("sh")
-            parts.append("-lc")
-            parts.append(shellQuoted(remoteCommand))
-        }
-
-        return parts.joined(separator: " ")
+        return parts
     }
 
     private static func remoteCommand(for profile: SSHProfile) -> String? {

--- a/Bellith/Views/Preferences/SSHPane.swift
+++ b/Bellith/Views/Preferences/SSHPane.swift
@@ -14,13 +14,15 @@ final class SSHPane: NSView {
     private let emptyStateLabel = FooterNote("No saved SSH profiles yet. Add one to create reusable connect commands.")
     private var profileRows: [SSHProfileRow] = []
 
-    private let connectionCard = SettingsCard(title: "Connection", subtitle: "Network identity and access path")
+    private let connectionCard = SettingsCard(title: "Connection", subtitle: "Network identity, transport, and access path")
     private let nameLabel = CardRowLabel("Profile Name")
     private var nameField: PrefTextField!
     private let hostLabel = CardRowLabel("Host")
     private var hostField: PrefTextField!
     private let userLabel = CardRowLabel("User")
     private var userField: PrefTextField!
+    private let transportLabel = CardRowLabel("Transport")
+    private var transportSegment: PrefSegment!
     private let portLabel = CardRowLabel("Port")
     private var portField: MiniNumberField!
     private let identityLabel = CardRowLabel("Identity File")
@@ -79,11 +81,33 @@ final class SSHPane: NSView {
         nameField = PrefTextField(text: "") { [weak self] value in self?.mutateSelectedProfile { $0.name = value } }
         hostField = PrefTextField(text: "") { [weak self] value in self?.mutateSelectedProfile { $0.host = value } }
         userField = PrefTextField(text: "") { [weak self] value in self?.mutateSelectedProfile { $0.user = value } }
+        transportSegment = PrefSegment(
+            labels: SSHTransport.allCases.map(\.title),
+            selected: 0
+        ) { [weak self] idx in
+            guard let transport = SSHTransport.allCases[safe: idx] else { return }
+            self?.mutateSelectedProfile { $0.transport = transport }
+        }
         portField = MiniNumberField(value: 22, range: 1...65_535) { [weak self] value in self?.mutateSelectedProfile { $0.port = value } }
         identityField = PrefTextField(text: "") { [weak self] value in self?.mutateSelectedProfile { $0.identityPath = value } }
         proxyJumpField = PrefTextField(text: "") { [weak self] value in self?.mutateSelectedProfile { $0.proxyJump = value } }
         content.addSubview(connectionCard)
-        for view: NSView in [nameLabel, nameField, hostLabel, hostField, userLabel, userField, portLabel, portField, identityLabel, identityField, proxyJumpLabel, proxyJumpField] {
+        for view: NSView in [
+            nameLabel,
+            nameField,
+            hostLabel,
+            hostField,
+            userLabel,
+            userField,
+            transportLabel,
+            transportSegment as NSView,
+            portLabel,
+            portField,
+            identityLabel,
+            identityField,
+            proxyJumpLabel,
+            proxyJumpField,
+        ] {
             connectionCard.addSubview(view)
         }
 
@@ -182,6 +206,7 @@ final class SSHPane: NSView {
             for field in [nameField, hostField, userField, identityField, proxyJumpField, cwdField, startupField, sessionNameField, environmentField, notesField] {
                 field?.updateText("")
             }
+            transportSegment.setSelected(0)
             portField.setValue(22)
             multiplexerSegment.setSelected(0)
             sensitiveToggle.setOn(false)
@@ -191,6 +216,7 @@ final class SSHPane: NSView {
         nameField.updateText(profile.name)
         hostField.updateText(profile.host)
         userField.updateText(profile.user)
+        transportSegment.setSelected(SSHTransport.allCases.firstIndex(of: profile.transport) ?? 0)
         portField.setValue(profile.port)
         identityField.updateText(profile.identityPath)
         proxyJumpField.updateText(profile.proxyJump)
@@ -283,8 +309,8 @@ final class SSHPane: NSView {
 
         if let _ = selectedProfile {
             let connectionHeight = connectionCard.headerHeight
-                + 6 * PreferencesLayout.rowH
-                + 5 * PreferencesLayout.rowGap
+                + 7 * PreferencesLayout.rowH
+                + 6 * PreferencesLayout.rowGap
                 + PreferencesLayout.cardPad
             connectionCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardW, height: connectionHeight)
             var rowY = connectionHeight - connectionCard.headerHeight - PreferencesLayout.rowH
@@ -292,6 +318,7 @@ final class SSHPane: NSView {
                 (nameLabel, nameField as NSView),
                 (hostLabel, hostField as NSView),
                 (userLabel, userField as NSView),
+                (transportLabel, transportSegment as NSView),
                 (portLabel, portField as NSView),
                 (identityLabel, identityField as NSView),
                 (proxyJumpLabel, proxyJumpField as NSView),

--- a/BellithTests/SSHLaunchBuilderTests.swift
+++ b/BellithTests/SSHLaunchBuilderTests.swift
@@ -7,6 +7,39 @@ final class SSHLaunchBuilderTests: XCTestCase {
         XCTAssertEqual(SSHLaunchBuilder.command(for: profile), "ssh 'deploy@app.example.com'")
     }
 
+    func testBuildsMoshCommandWithFallbackAndBootstrap() {
+        let profile = SSHProfile(
+            name: "Prod",
+            host: "prod.example.com",
+            user: "ops",
+            transport: .mosh,
+            port: 2222,
+            identityPath: "~/.ssh/prod",
+            proxyJump: "bastion",
+            defaultDirectory: "/srv/app",
+            startupCommand: "bin/deploy",
+            sessionBootstrap: .tmux,
+            sessionName: "prod"
+        )
+
+        let command = SSHLaunchBuilder.command(for: profile)
+        XCTAssertTrue(command.contains("if command -v mosh >/dev/null 2>&1; then"))
+        XCTAssertTrue(command.contains("ssh -p 2222 -i '~/.ssh/prod' -J 'bastion' 'ops@prod.example.com' -- sh -lc 'command -v mosh-server >/dev/null 2>&1'"))
+        XCTAssertTrue(command.contains("mosh --ssh='ssh -p 2222 -i '\\''~/.ssh/prod'\\'' -J '\\''bastion'\\''' 'ops@prod.example.com' sh -lc 'cd '\\''/srv/app'\\'' && tmux attach -t '\\''prod'\\'' || tmux new -s '\\''prod'\\'' && bin/deploy'"))
+        XCTAssertTrue(command.contains("printf '%s\\n' 'Bellith: mosh is not installed locally. Falling back to SSH.'"))
+        XCTAssertTrue(command.contains("printf '%s\\n' 'Bellith: mosh-server is unavailable on ops@prod.example.com. Falling back to SSH.'"))
+        XCTAssertTrue(command.contains("ssh -p 2222 -i '~/.ssh/prod' -J 'bastion' 'ops@prod.example.com' -- sh -lc 'cd '\\''/srv/app'\\'' && tmux attach -t '\\''prod'\\'' || tmux new -s '\\''prod'\\'' && bin/deploy'"))
+        XCTAssertFalse(command.contains("mosh --ssh='ssh -p 2222 -i '\\''~/.ssh/prod'\\'' -J '\\''bastion'\\''' 'ops@prod.example.com' -- sh -lc"))
+    }
+
+    func testBuildsMoshCommandWithoutRemoteBootstrapCommand() {
+        let profile = SSHProfile(name: "App", host: "app.example.com", user: "deploy", transport: .mosh)
+
+        let command = SSHLaunchBuilder.command(for: profile)
+        XCTAssertTrue(command.contains("mosh --ssh='ssh' 'deploy@app.example.com'"))
+        XCTAssertFalse(command.contains("mosh --ssh='ssh' 'deploy@app.example.com' sh -lc"))
+    }
+
     func testBuildsSSHCommandWithRemoteBootstrap() {
         let profile = SSHProfile(
             name: "Prod",

--- a/BellithTests/SSHProfileStoreTests.swift
+++ b/BellithTests/SSHProfileStoreTests.swift
@@ -25,13 +25,21 @@ final class SSHProfileStoreTests: XCTestCase {
     }
 
     func testRoundtripProfileSave() {
-        let profile = SSHProfile(name: "Prod", host: "prod.example.com", user: "deploy", environmentTag: "prod", isSensitive: true)
+        let profile = SSHProfile(
+            name: "Prod",
+            host: "prod.example.com",
+            user: "deploy",
+            transport: .mosh,
+            environmentTag: "prod",
+            isSensitive: true
+        )
         store.save([profile])
 
         let loaded = store.profiles
         XCTAssertEqual(loaded.count, 1)
         XCTAssertEqual(loaded.first?.displayName, "Prod")
         XCTAssertEqual(loaded.first?.host, "prod.example.com")
+        XCTAssertEqual(loaded.first?.transport, .mosh)
         XCTAssertTrue(loaded.first?.isSensitive ?? false)
     }
 
@@ -73,5 +81,18 @@ final class SSHProfileStoreTests: XCTestCase {
         let loaded = try XCTUnwrap(store.profiles.first)
         XCTAssertEqual(loaded.sessionBootstrap, .tmux)
         XCTAssertEqual(loaded.sessionName, "prod")
+    }
+
+    func testLegacyProfilesDefaultTransportToSSH() throws {
+        let object: [[String: Any]] = [[
+            "id": UUID().uuidString,
+            "name": "Prod",
+            "host": "prod.example.com"
+        ]]
+        let data = try JSONSerialization.data(withJSONObject: object)
+        defaults.set(data, forKey: "sshProfiles")
+
+        let loaded = try XCTUnwrap(store.profiles.first)
+        XCTAssertEqual(loaded.transport, .ssh)
     }
 }


### PR DESCRIPTION
## Summary
- add an SSH/Mosh transport toggle to saved SSH profiles
- generate mosh launch commands that preserve port, identity file, proxy jump, and remote bootstrap commands
- fall back to SSH with a clear terminal message when mosh is unavailable locally or remotely

## Testing
- `xcodebuild -project Bellith.xcodeproj -scheme Bellith -configuration Debug test -only-testing BellithTests/SSHLaunchBuilderTests -only-testing BellithTests/SSHProfileStoreTests`
- `xcodebuild -project Bellith.xcodeproj -scheme Bellith -configuration Debug test` *(currently fails in existing BellithSettingsTests/TerminalConfigTests with NSMenuItem submenu assertions unrelated to this change)*

Closes #38
