### PR TITLE
feat(preferences): add ssh jump host chaining

### DIFF
--- a/Bellith/Models/SSHProfile.swift
+++ b/Bellith/Models/SSHProfile.swift
@@ -40,6 +40,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
     var port: Int
     var identityPath: String
     var proxyJump: String
+    var proxyJumpProfileIDs: [UUID]
     var defaultDirectory: String
     var startupCommand: String
     var sessionBootstrap: SSHSessionBootstrap
@@ -57,6 +58,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
         port: Int = 22,
         identityPath: String = "",
         proxyJump: String = "",
+        proxyJumpProfileIDs: [UUID] = [],
         defaultDirectory: String = "",
         startupCommand: String = "",
         sessionBootstrap: SSHSessionBootstrap = .none,
@@ -87,6 +89,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
         self.port = port
         self.identityPath = identityPath
         self.proxyJump = proxyJump
+        self.proxyJumpProfileIDs = Self.normalizedProxyJumpProfileIDs(proxyJumpProfileIDs, excluding: id)
         self.defaultDirectory = defaultDirectory
         self.startupCommand = startupCommand
         self.sessionBootstrap = resolvedBootstrap
@@ -138,6 +141,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
             port: max(1, min(65_535, port)),
             identityPath: trimmedIdentityPath,
             proxyJump: trimmedProxyJump,
+            proxyJumpProfileIDs: Self.normalizedProxyJumpProfileIDs(proxyJumpProfileIDs, excluding: id),
             defaultDirectory: trimmedDefaultDirectory,
             startupCommand: trimmedStartupCommand,
             sessionBootstrap: trimmedSessionName.isEmpty ? .none : sessionBootstrap,
@@ -146,6 +150,48 @@ struct SSHProfile: Codable, Equatable, Identifiable {
             isSensitive: isSensitive,
             notes: trimmedNotes
         )
+    }
+
+    var hasProxyJumpProfileChain: Bool {
+        !proxyJumpProfileIDs.isEmpty
+    }
+
+    var legacyProxyJumpHops: [String] {
+        guard !hasProxyJumpProfileChain else { return [] }
+        return trimmedProxyJump
+            .split(separator: ",")
+            .map { Self.trimmed(String($0)) }
+            .filter { !$0.isEmpty }
+    }
+
+    func resolvedProxyJumpArgument(using profiles: [SSHProfile]) -> String {
+        guard hasProxyJumpProfileChain else { return trimmedProxyJump }
+
+        let lookup = Dictionary(uniqueKeysWithValues: profiles.map { ($0.id, $0) })
+        let resolved = proxyJumpProfileIDs.compactMap { profileID in
+            lookup[profileID]?.destination
+        }
+        .map(Self.trimmed)
+        .filter { !$0.isEmpty }
+
+        if resolved.count == proxyJumpProfileIDs.count, !resolved.isEmpty {
+            return resolved.joined(separator: ",")
+        }
+
+        return trimmedProxyJump
+    }
+
+    mutating func updateProxyJumpChain(profileIDs: [UUID], availableProfiles: [SSHProfile]) {
+        let normalizedProfileIDs = Self.normalizedProxyJumpProfileIDs(profileIDs, excluding: id)
+        let lookup = Dictionary(uniqueKeysWithValues: availableProfiles.map { ($0.id, $0) })
+        let resolvedChain = normalizedProfileIDs.compactMap { profileID in
+            lookup[profileID]?.destination
+        }
+        .map(Self.trimmed)
+        .filter { !$0.isEmpty }
+
+        proxyJumpProfileIDs = normalizedProfileIDs
+        proxyJump = resolvedChain.joined(separator: ",")
     }
 
     private var trimmedName: String { Self.trimmed(name) }
@@ -163,6 +209,14 @@ struct SSHProfile: Codable, Equatable, Identifiable {
         value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private static func normalizedProxyJumpProfileIDs(_ profileIDs: [UUID], excluding excludedID: UUID) -> [UUID] {
+        var seen = Set<UUID>()
+        return profileIDs.filter { profileID in
+            guard profileID != excludedID else { return false }
+            return seen.insert(profileID).inserted
+        }
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case name
@@ -172,6 +226,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
         case port
         case identityPath
         case proxyJump
+        case proxyJumpProfileIDs
         case defaultDirectory
         case startupCommand
         case sessionBootstrap
@@ -204,6 +259,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
             port: try container.decodeIfPresent(Int.self, forKey: .port) ?? 22,
             identityPath: try container.decodeIfPresent(String.self, forKey: .identityPath) ?? "",
             proxyJump: try container.decodeIfPresent(String.self, forKey: .proxyJump) ?? "",
+            proxyJumpProfileIDs: try container.decodeIfPresent([UUID].self, forKey: .proxyJumpProfileIDs) ?? [],
             defaultDirectory: try container.decodeIfPresent(String.self, forKey: .defaultDirectory) ?? "",
             startupCommand: try container.decodeIfPresent(String.self, forKey: .startupCommand) ?? "",
             sessionBootstrap: migratedBootstrap,
@@ -224,6 +280,7 @@ struct SSHProfile: Codable, Equatable, Identifiable {
         try container.encode(port, forKey: .port)
         try container.encode(identityPath, forKey: .identityPath)
         try container.encode(proxyJump, forKey: .proxyJump)
+        try container.encode(proxyJumpProfileIDs, forKey: .proxyJumpProfileIDs)
         try container.encode(defaultDirectory, forKey: .defaultDirectory)
         try container.encode(startupCommand, forKey: .startupCommand)
         try container.encode(sessionBootstrap, forKey: .sessionBootstrap)

--- a/Bellith/Services/SSHLaunchBuilder.swift
+++ b/Bellith/Services/SSHLaunchBuilder.swift
@@ -1,19 +1,23 @@
 import Foundation
 
 enum SSHLaunchBuilder {
-    static func command(for profile: SSHProfile) -> String {
+    static func command(for profile: SSHProfile, availableProfiles: [SSHProfile] = SSHProfileStore.shared.profiles) -> String {
         let profile = profile.sanitized()
 
         switch profile.transport {
         case .ssh:
-            return sshCommand(for: profile)
+            return sshCommand(for: profile, availableProfiles: availableProfiles)
         case .mosh:
-            return moshCommand(for: profile)
+            return moshCommand(for: profile, availableProfiles: availableProfiles)
         }
     }
 
-    private static func sshCommand(for profile: SSHProfile, remoteCommandOverride: String? = nil) -> String {
-        var parts = sshTransportParts(for: profile)
+    private static func sshCommand(
+        for profile: SSHProfile,
+        availableProfiles: [SSHProfile],
+        remoteCommandOverride: String? = nil
+    ) -> String {
+        var parts = sshTransportParts(for: profile, availableProfiles: availableProfiles)
         parts.append(shellQuoted(profile.destination))
 
         if let remoteCommand = remoteCommandOverride ?? remoteCommand(for: profile) {
@@ -26,13 +30,14 @@ enum SSHLaunchBuilder {
         return parts.joined(separator: " ")
     }
 
-    private static func moshCommand(for profile: SSHProfile) -> String {
-        let fallbackSSHCommand = sshCommand(for: profile)
+    private static func moshCommand(for profile: SSHProfile, availableProfiles: [SSHProfile]) -> String {
+        let fallbackSSHCommand = sshCommand(for: profile, availableProfiles: availableProfiles)
         let remoteCheckCommand = sshCommand(
             for: profile,
+            availableProfiles: availableProfiles,
             remoteCommandOverride: "command -v mosh-server >/dev/null 2>&1"
         )
-        let remoteLaunchCommand = moshLaunchCommand(for: profile)
+        let remoteLaunchCommand = moshLaunchCommand(for: profile, availableProfiles: availableProfiles)
         let localFallbackMessage = "Bellith: mosh is not installed locally. Falling back to SSH."
         let remoteFallbackMessage = "Bellith: mosh-server is unavailable on \(profile.destination). Falling back to SSH."
 
@@ -51,10 +56,10 @@ enum SSHLaunchBuilder {
         """
     }
 
-    private static func moshLaunchCommand(for profile: SSHProfile) -> String {
+    private static func moshLaunchCommand(for profile: SSHProfile, availableProfiles: [SSHProfile]) -> String {
         var parts = [
             "mosh",
-            "--ssh=\(shellQuoted(sshTransportCommand(for: profile)))",
+            "--ssh=\(shellQuoted(sshTransportCommand(for: profile, availableProfiles: availableProfiles)))",
             shellQuoted(profile.destination),
         ]
 
@@ -67,11 +72,11 @@ enum SSHLaunchBuilder {
         return parts.joined(separator: " ")
     }
 
-    private static func sshTransportCommand(for profile: SSHProfile) -> String {
-        sshTransportParts(for: profile).joined(separator: " ")
+    private static func sshTransportCommand(for profile: SSHProfile, availableProfiles: [SSHProfile]) -> String {
+        sshTransportParts(for: profile, availableProfiles: availableProfiles).joined(separator: " ")
     }
 
-    private static func sshTransportParts(for profile: SSHProfile) -> [String] {
+    private static func sshTransportParts(for profile: SSHProfile, availableProfiles: [SSHProfile]) -> [String] {
         var parts = ["ssh"]
 
         if profile.port != 22 {
@@ -84,9 +89,10 @@ enum SSHLaunchBuilder {
             parts.append(shellQuoted(profile.identityPath))
         }
 
-        if !profile.proxyJump.isEmpty {
+        let proxyJumpArgument = profile.resolvedProxyJumpArgument(using: availableProfiles)
+        if !proxyJumpArgument.isEmpty {
             parts.append("-J")
-            parts.append(shellQuoted(profile.proxyJump))
+            parts.append(shellQuoted(proxyJumpArgument))
         }
 
         return parts

--- a/Bellith/Views/Preferences/SSHPane.swift
+++ b/Bellith/Views/Preferences/SSHPane.swift
@@ -27,8 +27,8 @@ final class SSHPane: NSView {
     private var portField: MiniNumberField!
     private let identityLabel = CardRowLabel("Identity File")
     private var identityField: PrefTextField!
-    private let proxyJumpLabel = CardRowLabel("ProxyJump")
-    private var proxyJumpField: PrefTextField!
+    private let proxyJumpLabel = CardRowLabel("Jump Hosts")
+    private var proxyJumpEditor: SSHProxyJumpEditorView!
 
     private let sessionCard = SettingsCard(title: "Bootstrap", subtitle: "Remote shell setup applied after the SSH session starts")
     private let cwdLabel = CardRowLabel("Remote Directory")
@@ -90,7 +90,25 @@ final class SSHPane: NSView {
         }
         portField = MiniNumberField(value: 22, range: 1...65_535) { [weak self] value in self?.mutateSelectedProfile { $0.port = value } }
         identityField = PrefTextField(text: "") { [weak self] value in self?.mutateSelectedProfile { $0.identityPath = value } }
-        proxyJumpField = PrefTextField(text: "") { [weak self] value in self?.mutateSelectedProfile { $0.proxyJump = value } }
+        proxyJumpEditor = SSHProxyJumpEditorView()
+        proxyJumpEditor.onAddProfile = { [weak self] jumpProfileID in
+            guard let self else { return }
+            self.mutateSelectedProfile { profile in
+                profile.updateProxyJumpChain(
+                    profileIDs: profile.proxyJumpProfileIDs + [jumpProfileID],
+                    availableProfiles: self.profiles
+                )
+            }
+        }
+        proxyJumpEditor.onRemoveProfile = { [weak self] jumpProfileID in
+            guard let self else { return }
+            self.mutateSelectedProfile { profile in
+                profile.updateProxyJumpChain(
+                    profileIDs: profile.proxyJumpProfileIDs.filter { $0 != jumpProfileID },
+                    availableProfiles: self.profiles
+                )
+            }
+        }
         content.addSubview(connectionCard)
         for view: NSView in [
             nameLabel,
@@ -106,7 +124,7 @@ final class SSHPane: NSView {
             identityLabel,
             identityField,
             proxyJumpLabel,
-            proxyJumpField,
+            proxyJumpEditor,
         ] {
             connectionCard.addSubview(view)
         }
@@ -203,13 +221,14 @@ final class SSHPane: NSView {
 
     private func updateFieldValues() {
         guard let profile = selectedProfile else {
-            for field in [nameField, hostField, userField, identityField, proxyJumpField, cwdField, startupField, sessionNameField, environmentField, notesField] {
+            for field in [nameField, hostField, userField, identityField, cwdField, startupField, sessionNameField, environmentField, notesField] {
                 field?.updateText("")
             }
             transportSegment.setSelected(0)
             portField.setValue(22)
             multiplexerSegment.setSelected(0)
             sensitiveToggle.setOn(false)
+            proxyJumpEditor.update(profile: nil, availableProfiles: profiles)
             return
         }
 
@@ -219,7 +238,7 @@ final class SSHPane: NSView {
         transportSegment.setSelected(SSHTransport.allCases.firstIndex(of: profile.transport) ?? 0)
         portField.setValue(profile.port)
         identityField.updateText(profile.identityPath)
-        proxyJumpField.updateText(profile.proxyJump)
+        proxyJumpEditor.update(profile: profile, availableProfiles: profiles)
         cwdField.updateText(profile.defaultDirectory)
         startupField.updateText(profile.startupCommand)
         multiplexerSegment.setSelected(SSHSessionBootstrap.allCases.firstIndex(of: profile.sessionBootstrap) ?? 0)
@@ -308,8 +327,10 @@ final class SSHPane: NSView {
         y += profilesCardHeight + PreferencesLayout.sectionGap
 
         if let _ = selectedProfile {
+            let proxyJumpHeight = SSHProxyJumpEditorView.preferredHeight
             let connectionHeight = connectionCard.headerHeight
-                + 7 * PreferencesLayout.rowH
+                + 6 * PreferencesLayout.rowH
+                + proxyJumpHeight
                 + 6 * PreferencesLayout.rowGap
                 + PreferencesLayout.cardPad
             connectionCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardW, height: connectionHeight)
@@ -321,12 +342,20 @@ final class SSHPane: NSView {
                 (transportLabel, transportSegment as NSView),
                 (portLabel, portField as NSView),
                 (identityLabel, identityField as NSView),
-                (proxyJumpLabel, proxyJumpField as NSView),
             ] {
                 label.frame = NSRect(x: PreferencesLayout.cardPad, y: rowY, width: labelW - 12, height: PreferencesLayout.rowH)
                 control.frame = NSRect(x: controlX, y: rowY + 6, width: controlW, height: 28)
                 rowY -= PreferencesLayout.rowH + PreferencesLayout.rowGap
             }
+
+            let proxyJumpRowY = rowY - (proxyJumpHeight - PreferencesLayout.rowH)
+            proxyJumpLabel.frame = NSRect(
+                x: PreferencesLayout.cardPad,
+                y: proxyJumpRowY + max(0, proxyJumpHeight - PreferencesLayout.rowH),
+                width: labelW - 12,
+                height: PreferencesLayout.rowH
+            )
+            proxyJumpEditor.frame = NSRect(x: controlX, y: proxyJumpRowY + 4, width: controlW, height: proxyJumpHeight - 8)
             y += connectionHeight + PreferencesLayout.sectionGap
 
             let sessionHeight = sessionCard.headerHeight
@@ -362,6 +391,260 @@ final class SSHPane: NSView {
         }
 
         content.frame = NSRect(x: 0, y: 0, width: width, height: max(y, bounds.height))
+    }
+}
+
+private struct SSHProxyJumpHopItem {
+    let id: UUID?
+    let title: String
+    let isMissing: Bool
+}
+
+private final class SSHProxyJumpEditorView: NSView {
+    static let preferredHeight: CGFloat = 62
+
+    var onAddProfile: ((UUID) -> Void)?
+    var onRemoveProfile: ((UUID) -> Void)?
+
+    private let chainView = SSHProxyJumpChainView()
+    private let addPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+
+        chainView.onRemoveHop = { [weak self] hopID in
+            self?.onRemoveProfile?(hopID)
+        }
+        addSubview(chainView)
+
+        addPopup.font = BellithFont.mono(12, weight: .regular)
+        addPopup.focusRingType = .none
+        addPopup.target = self
+        addPopup.action = #selector(handleAddProfile)
+        addSubview(addPopup)
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    override func layout() {
+        super.layout()
+        chainView.frame = NSRect(x: 0, y: bounds.height - 28, width: bounds.width, height: 28)
+        addPopup.frame = NSRect(x: 0, y: 0, width: bounds.width, height: 28)
+    }
+
+    func update(profile: SSHProfile?, availableProfiles allProfiles: [SSHProfile]) {
+        guard let profile else {
+            chainView.update(hops: [])
+            rebuildAddPopup(selectedProfileID: nil, selectedJumpProfileIDs: [], availableProfiles: [])
+            return
+        }
+
+        let lookup = Dictionary(uniqueKeysWithValues: allProfiles.map { ($0.id, $0) })
+        let hops: [SSHProxyJumpHopItem]
+        if profile.hasProxyJumpProfileChain {
+            hops = profile.proxyJumpProfileIDs.map { profileID in
+                if let jumpProfile = lookup[profileID] {
+                    return SSHProxyJumpHopItem(
+                        id: profileID,
+                        title: jumpProfile.displayName.uppercased(),
+                        isMissing: false
+                    )
+                }
+                return SSHProxyJumpHopItem(id: profileID, title: "MISSING HOST", isMissing: true)
+            }
+        } else {
+            hops = profile.legacyProxyJumpHops.map {
+                SSHProxyJumpHopItem(id: nil, title: $0.uppercased(), isMissing: true)
+            }
+        }
+
+        chainView.update(hops: hops)
+        rebuildAddPopup(
+            selectedProfileID: profile.id,
+            selectedJumpProfileIDs: Set(profile.proxyJumpProfileIDs),
+            availableProfiles: allProfiles
+        )
+    }
+
+    @objc private func handleAddProfile() {
+        defer { addPopup.selectItem(at: 0) }
+        guard addPopup.indexOfSelectedItem > 0,
+              let jumpProfileID = addPopup.selectedItem?.representedObject as? UUID else { return }
+        onAddProfile?(jumpProfileID)
+    }
+
+    private func rebuildAddPopup(
+        selectedProfileID: UUID?,
+        selectedJumpProfileIDs: Set<UUID>,
+        availableProfiles: [SSHProfile]
+    ) {
+        addPopup.removeAllItems()
+        addPopup.addItem(withTitle: "Add jump host…")
+        addPopup.lastItem?.representedObject = nil
+
+        let eligibleProfiles = availableProfiles.filter { profile in
+            guard profile.id != selectedProfileID else { return false }
+            return !selectedJumpProfileIDs.contains(profile.id)
+        }
+
+        for profile in eligibleProfiles {
+            let title = profile.destination.isEmpty
+                ? profile.displayName
+                : "\(profile.displayName) — \(profile.destination)"
+            addPopup.addItem(withTitle: title)
+            addPopup.lastItem?.representedObject = profile.id
+        }
+
+        addPopup.selectItem(at: 0)
+        addPopup.isEnabled = selectedProfileID != nil && !eligibleProfiles.isEmpty
+        if !addPopup.isEnabled {
+            addPopup.item(at: 0)?.title = selectedProfileID == nil ? "Add jump host…" : "No other saved hosts"
+        }
+    }
+}
+
+private final class SSHProxyJumpChainView: NSView {
+    var onRemoveHop: ((UUID) -> Void)?
+
+    private let emptyLabel = NSTextField(labelWithString: "DIRECT CONNECTION")
+    private var hopViews: [SSHProxyJumpHopBadgeView] = []
+    private var arrowViews: [NSImageView] = []
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.borderWidth = 0.5
+
+        emptyLabel.font = BellithFont.mono(10, weight: .regular)
+        emptyLabel.textColor = Theme.textTertiary
+        addSubview(emptyLabel)
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    override func layout() {
+        super.layout()
+        layer?.backgroundColor = Theme.frame.cgColor
+        layer?.borderColor = Theme.border.cgColor
+        emptyLabel.textColor = Theme.textTertiary
+        emptyLabel.frame = bounds.insetBy(dx: 10, dy: 7)
+
+        let inset: CGFloat = 8
+        let arrowWidth: CGFloat = 14
+        let hopHeight = bounds.height - 8
+        let maxHopWidth = max(72, (bounds.width - inset * 2 - CGFloat(max(0, hopViews.count - 1)) * arrowWidth) / CGFloat(max(hopViews.count, 1)))
+
+        var x = inset
+        for (index, hopView) in hopViews.enumerated() {
+            let remainingWidth = max(72, bounds.width - inset - x)
+            let width = min(hopView.preferredWidth, maxHopWidth, remainingWidth)
+            hopView.frame = NSRect(x: x, y: 4, width: width, height: hopHeight)
+            x += width
+
+            if let arrowView = arrowViews[safe: index] {
+                arrowView.frame = NSRect(x: x, y: (bounds.height - 12) / 2, width: arrowWidth, height: 12)
+                x += arrowWidth
+            }
+        }
+    }
+
+    func update(hops: [SSHProxyJumpHopItem]) {
+        hopViews.forEach { $0.removeFromSuperview() }
+        arrowViews.forEach { $0.removeFromSuperview() }
+        hopViews.removeAll()
+        arrowViews.removeAll()
+
+        emptyLabel.isHidden = !hops.isEmpty
+
+        for (index, hop) in hops.enumerated() {
+            let hopView = SSHProxyJumpHopBadgeView()
+            hopView.update(hop: hop)
+            hopView.onRemove = { [weak self] in
+                guard let hopID = hop.id else { return }
+                self?.onRemoveHop?(hopID)
+            }
+            addSubview(hopView)
+            hopViews.append(hopView)
+
+            if index < hops.count - 1 {
+                let arrowView = NSImageView()
+                arrowView.image = NSImage(systemSymbolName: "chevron.right", accessibilityDescription: nil)
+                arrowView.contentTintColor = Theme.textTertiary
+                arrowView.imageScaling = .scaleProportionallyDown
+                addSubview(arrowView)
+                arrowViews.append(arrowView)
+            }
+        }
+
+        needsLayout = true
+    }
+}
+
+private final class SSHProxyJumpHopBadgeView: NSView {
+    var onRemove: (() -> Void)?
+
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let removeButton = NSButton()
+    private var isMissing = false
+    private var showsRemoveButton = false
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+        layer?.cornerRadius = 7
+        layer?.borderWidth = 0.5
+
+        titleLabel.font = BellithFont.mono(10, weight: .regular)
+        titleLabel.lineBreakMode = .byTruncatingTail
+        addSubview(titleLabel)
+
+        removeButton.isBordered = false
+        removeButton.image = NSImage(systemSymbolName: "xmark.circle.fill", accessibilityDescription: "Remove jump host")
+        removeButton.imageScaling = .scaleProportionallyDown
+        removeButton.target = self
+        removeButton.action = #selector(handleRemove)
+        addSubview(removeButton)
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    var preferredWidth: CGFloat {
+        let measuredWidth = (titleLabel.stringValue as NSString).size(withAttributes: [.font: titleLabel.font as Any]).width
+        let removeWidth: CGFloat = showsRemoveButton ? 22 : 0
+        return min(160, max(72, measuredWidth + removeWidth + 20))
+    }
+
+    override func layout() {
+        super.layout()
+        refreshAppearance()
+
+        if showsRemoveButton {
+            removeButton.frame = NSRect(x: bounds.width - 18, y: (bounds.height - 12) / 2, width: 12, height: 12)
+            titleLabel.frame = NSRect(x: 8, y: 4, width: bounds.width - 30, height: bounds.height - 8)
+        } else {
+            removeButton.frame = .zero
+            titleLabel.frame = NSRect(x: 8, y: 4, width: bounds.width - 16, height: bounds.height - 8)
+        }
+    }
+
+    func update(hop: SSHProxyJumpHopItem) {
+        titleLabel.stringValue = hop.title
+        isMissing = hop.isMissing
+        showsRemoveButton = hop.id != nil
+        removeButton.isHidden = !showsRemoveButton
+        needsLayout = true
+    }
+
+    @objc private func handleRemove() {
+        onRemove?()
+    }
+
+    private func refreshAppearance() {
+        layer?.backgroundColor = (isMissing ? Theme.overlay.withAlphaComponent(0.28) : Theme.chromeElevated).cgColor
+        layer?.borderColor = (isMissing ? Theme.border : Theme.chromeHairline).cgColor
+        titleLabel.textColor = isMissing ? Theme.textSecondary : Theme.textPrimary
+        removeButton.contentTintColor = Theme.textTertiary
     }
 }
 

--- a/BellithTests/SSHLaunchBuilderTests.swift
+++ b/BellithTests/SSHLaunchBuilderTests.swift
@@ -7,6 +7,39 @@ final class SSHLaunchBuilderTests: XCTestCase {
         XCTAssertEqual(SSHLaunchBuilder.command(for: profile), "ssh 'deploy@app.example.com'")
     }
 
+    func testBuildsSSHCommandWithResolvedProxyJumpChainFromSavedProfiles() {
+        let bastion = SSHProfile(name: "Bastion", host: "bastion.example.com", user: "jump")
+        let relay = SSHProfile(name: "Relay", host: "relay.example.com")
+        let profile = SSHProfile(
+            name: "Prod",
+            host: "prod.example.com",
+            user: "ops",
+            proxyJump: "stale-hop",
+            proxyJumpProfileIDs: [bastion.id, relay.id]
+        )
+
+        XCTAssertEqual(
+            SSHLaunchBuilder.command(for: profile, availableProfiles: [bastion, relay, profile]),
+            "ssh -J 'jump@bastion.example.com,relay.example.com' 'ops@prod.example.com'"
+        )
+    }
+
+    func testFallsBackToStoredProxyJumpWhenReferencedProfileIsMissing() {
+        let missingJump = UUID()
+        let profile = SSHProfile(
+            name: "Prod",
+            host: "prod.example.com",
+            user: "ops",
+            proxyJump: "legacy-bastion",
+            proxyJumpProfileIDs: [missingJump]
+        )
+
+        XCTAssertEqual(
+            SSHLaunchBuilder.command(for: profile, availableProfiles: [profile]),
+            "ssh -J 'legacy-bastion' 'ops@prod.example.com'"
+        )
+    }
+
     func testBuildsMoshCommandWithFallbackAndBootstrap() {
         let profile = SSHProfile(
             name: "Prod",

--- a/BellithTests/SSHProfileStoreTests.swift
+++ b/BellithTests/SSHProfileStoreTests.swift
@@ -54,6 +54,22 @@ final class SSHProfileStoreTests: XCTestCase {
         XCTAssertEqual(store.profiles.first?.user, "root")
     }
 
+    func testRoundtripProxyJumpProfileIDs() throws {
+        let bastion = SSHProfile(name: "Bastion", host: "bastion.example.com")
+        let profile = SSHProfile(
+            name: "Prod",
+            host: "prod.example.com",
+            proxyJump: "bastion.example.com",
+            proxyJumpProfileIDs: [bastion.id]
+        )
+
+        store.save([bastion, profile])
+
+        let loadedProfile = try XCTUnwrap(store.profiles.first(where: { $0.id == profile.id }))
+        XCTAssertEqual(loadedProfile.proxyJumpProfileIDs, [bastion.id])
+        XCTAssertEqual(loadedProfile.proxyJump, "bastion.example.com")
+    }
+
     func testDeleteProfileRemovesStoredItem() {
         let profile = SSHProfile(name: "Logs", host: "logs.example.com")
         store.save([profile])


### PR DESCRIPTION
## Summary
- add saved jump host chains to SSH profiles and resolve them into `-J host1,host2` at launch time
- replace the free-form ProxyJump text field with a native jump host picker and visual hop chain in the SSH preferences pane
- persist jump host profile IDs with snapshot fallback coverage and add regression tests for launch building and storage

Closes #53

## Testing
- make build
- xcodebuild test -scheme Bellith -only-testing:BellithTests/SSHLaunchBuilderTests -only-testing:BellithTests/SSHProfileStoreTests
- make test *(currently fails on existing unrelated `NSMenuItem setSubmenu:` assertions in `BellithSettingsTests` and `TerminalConfigTests`)*
