### PR TITLE
feat(ui): drag tabs between windows

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		3F067DBCA20A52FB30980DA2 /* SSHProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AC775F3A6A91CF3FE4CDAB /* SSHProfileStoreTests.swift */; };
 		3F81E95CDC0FF4142056C98A /* EnvironmentPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0B5E50A6BE76A1D3EDFE6D /* EnvironmentPanel.swift */; };
 		3FE2152821D44C82B14D0338 /* WallpaperTint.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD317F56432F400BA1567BB /* WallpaperTint.swift */; };
+		448B3D29B0C3C5D8F8A35CC4 /* TabDragPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC212B83257FCC23F5592D /* TabDragPayload.swift */; };
 		459FB063C7F788F4E0E549A5 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89FDA87579791818D3A6718 /* TerminalPane.swift */; };
 		462CADCA785D176937B5F445 /* GitRepositoryInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC203E445CE586B521D8FC29 /* GitRepositoryInfoTests.swift */; };
 		4859630C40EA72D0F6A13448 /* SSHLaunchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A6320778E024E8ABCDF2A6 /* SSHLaunchBuilder.swift */; };
@@ -144,6 +145,7 @@
 		3C9D96FFF53397D45EA101F4 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
 		41878447E775AEA363F6EF96 /* TerminalSurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceView.swift; sourceTree = "<group>"; };
 		419904C2F6EF539F340C4054 /* GitHubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubService.swift; sourceTree = "<group>"; };
+		42FC212B83257FCC23F5592D /* TabDragPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDragPayload.swift; sourceTree = "<group>"; };
 		469D41729D62F6520EB09E3B /* SmartPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPanelView.swift; sourceTree = "<group>"; };
 		4AAC0EE06A46735764D38F77 /* ToolActivityPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityPanel.swift; sourceTree = "<group>"; };
 		4FD22E965C6F1A921DC3AFFA /* BellithSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellithSettingsTests.swift; sourceTree = "<group>"; };
@@ -392,6 +394,7 @@
 				90AD21D2101DAB69E92DFB59 /* SessionState.swift */,
 				17F1A89752C176F1F7719413 /* ShortcutDefinitions.swift */,
 				359237193DE4C0621F16BDD8 /* SSHProfile.swift */,
+				42FC212B83257FCC23F5592D /* TabDragPayload.swift */,
 				FC5966D19E6F059737E8B875 /* TerminalContext.swift */,
 				772785F1920803E52A7235C8 /* TerminalProfile.swift */,
 				5B639E55908BD9DDCD969BFE /* WorkspaceDefinition.swift */,
@@ -676,6 +679,7 @@
 				0FF0294C8F9B14B9DBB9051F /* SplitPaneView.swift in Sources */,
 				A86738D1AB23F41A78A329D6 /* StatusBarView.swift in Sources */,
 				AAEC14C4379EFD86E0A0BCCE /* TabBarView.swift in Sources */,
+				448B3D29B0C3C5D8F8A35CC4 /* TabDragPayload.swift in Sources */,
 				DBFD98B2DDBABADA6AA755D7 /* TerminalApp.swift in Sources */,
 				D9B06ED212407C4E58B58CE2 /* TerminalConfig.swift in Sources */,
 				F0688F637632B59A01825393 /* TerminalContainerView.swift in Sources */,

--- a/Bellith/App/AppDelegate.swift
+++ b/Bellith/App/AppDelegate.swift
@@ -32,6 +32,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let container: TerminalContainerView
     }
 
+    private func entry(forWindowID id: UUID) -> WindowEntry? {
+        windows.first { $0.window.tabDragIdentifier == id }
+    }
+
     /// The key (focused) window's container, or the most recent one.
     private var activeEntry: WindowEntry? {
         if let keyWindow = NSApp.keyWindow as? TerminalWindow {
@@ -198,7 +202,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private func createWindow(
         session: SessionState? = nil,
         initialWorkingDirectory: String? = nil,
-        frameDescriptor: String? = nil
+        frameDescriptor: String? = nil,
+        createInitialTab: Bool = true,
+        orderFront: Bool = true,
+        dropScreenPoint: NSPoint? = nil
     ) -> WindowEntry? {
         guard let terminalApp else { return nil }
 
@@ -216,13 +223,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             } else {
                 window.center()
             }
+        } else if let dropScreenPoint {
+            position(window, around: dropScreenPoint)
         } else {
             window.center()
         }
         window.isReleasedWhenClosed = false
         window.delegate = self
 
-        let container = TerminalContainerView(terminalApp: terminalApp, dependencies: dependencies)
+        let container = TerminalContainerView(
+            terminalApp: terminalApp,
+            createInitialTab: createInitialTab,
+            dependencies: dependencies
+        )
         let backdrop = BackdropView(container: container)
         window.contentView = backdrop
 
@@ -236,9 +249,77 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
 
         window.makeFirstResponder(container.activeSurface ?? container)
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate()
+        if orderFront {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate()
+        }
         return entry
+    }
+
+    private func position(_ window: NSWindow, around screenPoint: NSPoint) {
+        let frame = window.frame
+        let visibleFrame = window.screen?.visibleFrame
+            ?? NSScreen.screens.first(where: { NSMouseInRect(screenPoint, $0.frame, false) })?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+
+        let targetOrigin = NSPoint(
+            x: screenPoint.x - frame.width / 2,
+            y: screenPoint.y - frame.height + 28
+        )
+        let clampedOrigin = NSPoint(
+            x: min(max(targetOrigin.x, visibleFrame.minX), visibleFrame.maxX - frame.width),
+            y: min(max(targetOrigin.y, visibleFrame.minY), visibleFrame.maxY - frame.height)
+        )
+        window.setFrameOrigin(clampedOrigin)
+    }
+
+    func moveTab(
+        _ tabID: UUID,
+        fromWindowWithID sourceWindowID: UUID,
+        toWindowWithID destinationWindowID: UUID,
+        insertionIndex: Int
+    ) -> Bool {
+        guard sourceWindowID != destinationWindowID,
+              let sourceEntry = entry(forWindowID: sourceWindowID),
+              let destinationEntry = entry(forWindowID: destinationWindowID),
+              let entry = sourceEntry.container.detachTab(withID: tabID) else {
+            return false
+        }
+
+        destinationEntry.container.insertTransferredTab(entry, at: insertionIndex)
+        destinationEntry.window.makeFirstResponder(destinationEntry.container.activeSurface ?? destinationEntry.container)
+        destinationEntry.window.makeKeyAndOrderFront(nil)
+        NSApp.activate()
+        return true
+    }
+
+    func tearOffTab(
+        _ tabID: UUID,
+        fromWindowWithID sourceWindowID: UUID,
+        dropScreenPoint: NSPoint
+    ) -> Bool {
+        guard entry(forWindowID: sourceWindowID) != nil,
+              let destinationEntry = createWindow(
+                  createInitialTab: false,
+                  orderFront: false,
+                  dropScreenPoint: dropScreenPoint
+              ) else {
+            return false
+        }
+
+        guard let sourceEntry = entry(forWindowID: sourceWindowID),
+              let entry = sourceEntry.container.detachTab(withID: tabID) else {
+            destinationEntry.window.close()
+            return false
+        }
+
+        destinationEntry.container.insertTransferredTab(entry, at: 0)
+        position(destinationEntry.window, around: dropScreenPoint)
+        destinationEntry.window.makeFirstResponder(destinationEntry.container.activeSurface ?? destinationEntry.container)
+        destinationEntry.window.makeKeyAndOrderFront(nil)
+        NSApp.activate()
+        return true
     }
 
     private func restoreSavedWindows() -> Bool {

--- a/Bellith/Models/TabDragPayload.swift
+++ b/Bellith/Models/TabDragPayload.swift
@@ -1,0 +1,29 @@
+import AppKit
+import Foundation
+
+struct TabDragPayload: Codable, Equatable {
+    static let pasteboardType = NSPasteboard.PasteboardType("com.rec.bellith.tab")
+
+    let sourceWindowID: UUID
+    let tabID: UUID
+
+    private var encodedData: Data? {
+        try? JSONEncoder().encode(self)
+    }
+
+    func write(to pasteboard: NSPasteboard) {
+        guard let encodedData else { return }
+        pasteboard.clearContents()
+        pasteboard.setData(encodedData, forType: Self.pasteboardType)
+    }
+
+    func set(on pasteboardItem: NSPasteboardItem) {
+        guard let encodedData else { return }
+        pasteboardItem.setData(encodedData, forType: Self.pasteboardType)
+    }
+
+    static func read(from pasteboard: NSPasteboard) -> TabDragPayload? {
+        guard let data = pasteboard.data(forType: Self.pasteboardType) else { return nil }
+        return try? JSONDecoder().decode(Self.self, from: data)
+    }
+}

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -801,6 +801,14 @@ fileprivate final class SidebarTabRow: NSView {
 
     override var mouseDownCanMoveWindow: Bool { false }
 
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard bounds.contains(point) else { return nil }
+        if closeButton.frame.contains(point) {
+            return closeButton
+        }
+        return self
+    }
+
     private let selectionIndicator = CALayer()
     private let iconPlate = CALayer()
     private let iconView = NSImageView()

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -67,6 +67,10 @@ final class SidebarView: NSView, NSDraggingSource {
 
     var windowIdentifier: UUID?
 
+    private var effectiveWindowIdentifier: UUID? {
+        windowIdentifier ?? (window as? TerminalWindow)?.tabDragIdentifier
+    }
+
     /// Called when a tool is clicked in the sidebar. The container opens it in the main content area.
     var onSelectTool: ((String) -> Void)?
 
@@ -518,7 +522,7 @@ final class SidebarView: NSView, NSDraggingSource {
     private func beginDragSession(fromVisibleIndex visibleIndex: Int, event: NSEvent, dragView: NSView) {
         guard dragSourceIndex == nil,
               visibleIndex >= 0, visibleIndex < tabRows.count,
-              let windowIdentifier,
+              let windowIdentifier = effectiveWindowIdentifier,
               let draggingImage = dragImage(for: dragView) else { return }
 
         let sourceTabIndex = tabRowSourceIndices[visibleIndex]
@@ -689,7 +693,7 @@ final class SidebarView: NSView, NSDraggingSource {
         let requestedInsertionIndex = sourceInsertionIndex(forVisibleInsertionIndex: visibleInsertionIndex)
         let sourceTabIndex = tabs.firstIndex(where: { $0.id == payload.tabID })
 
-        if payload.sourceWindowID == windowIdentifier, let sourceTabIndex {
+        if payload.sourceWindowID == effectiveWindowIdentifier, let sourceTabIndex {
             let destinationIndex = Self.reorderDestinationIndex(
                 sourceIndex: sourceTabIndex,
                 insertionIndex: requestedInsertionIndex,

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -3,6 +3,7 @@ import QuartzCore
 
 /// Monochrome utility sidebar with restrained chrome and strong type hierarchy.
 final class SidebarView: NSView, NSDraggingSource {
+    override var mouseDownCanMoveWindow: Bool { false }
     typealias TabModel = (id: UUID, title: String, kind: TerminalContainerView.TabKind)
 
     struct SettingsSnapshot: Equatable {
@@ -526,7 +527,7 @@ final class SidebarView: NSView, NSDraggingSource {
         payload.set(on: pasteboardItem)
 
         let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
-        draggingItem.setDraggingFrame(convert(dragView.bounds, from: dragView), contents: draggingImage)
+        draggingItem.setDraggingFrame(dragView.bounds, contents: draggingImage)
 
         dragSourceIndex = visibleIndex
         dragInsertionIndex = nil
@@ -534,20 +535,23 @@ final class SidebarView: NSView, NSDraggingSource {
         ensureDragIndicator()
         dragIndicatorLayer?.isHidden = true
 
-        let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
+        let session = dragView.beginDraggingSession(with: [draggingItem], event: event, source: self)
         session.animatesToStartingPositionsOnCancelOrFail = false
         session.draggingFormation = .none
     }
 
     private func dragImage(for view: NSView) -> NSImage? {
-        guard view.bounds.width > 0, view.bounds.height > 0,
-              let representation = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
-            return nil
+        guard view.bounds.width > 0, view.bounds.height > 0 else { return nil }
+
+        if let representation = view.bitmapImageRepForCachingDisplay(in: view.bounds) {
+            view.cacheDisplay(in: view.bounds, to: representation)
+            let image = NSImage(size: view.bounds.size)
+            image.addRepresentation(representation)
+            return image
         }
-        view.cacheDisplay(in: view.bounds, to: representation)
-        let image = NSImage(size: view.bounds.size)
-        image.addRepresentation(representation)
-        return image
+
+        let pdfData = view.dataWithPDF(inside: view.bounds)
+        return NSImage(data: pdfData)
     }
 
     private func ensureDragIndicator() {
@@ -800,6 +804,8 @@ fileprivate final class SidebarTabRow: NSView {
     private var mouseDownLocation: NSPoint?
 
     override var mouseDownCanMoveWindow: Bool { false }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         guard bounds.contains(point) else { return nil }

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -853,9 +853,6 @@ fileprivate final class SidebarTabRow: NSView {
     var onDragMoved: ((NSEvent) -> Void)?
     var onDragEnded: ((NSEvent) -> Void)?
     var onRightClick: ((NSPoint) -> Void)?
-    private var isDragging = false
-    private var mouseDownLocation: NSPoint?
-
     override var mouseDownCanMoveWindow: Bool { false }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
@@ -986,30 +983,30 @@ fileprivate final class SidebarTabRow: NSView {
     override func mouseDown(with event: NSEvent) {
         let loc = convert(event.locationInWindow, from: nil)
         if closeButton.frame.contains(loc) { onClose?(); return }
-        mouseDownLocation = event.locationInWindow
-        isDragging = false
-    }
 
-    override func mouseDragged(with event: NSEvent) {
-        guard let start = mouseDownLocation else { return }
-        let loc = event.locationInWindow
-        if !isDragging && hypot(loc.x - start.x, loc.y - start.y) > 4 {
-            isDragging = true
-        }
-        if isDragging {
-            onDragMoved?(event)
-        }
-    }
+        let start = event.locationInWindow
+        var isDragging = false
 
-    override func mouseUp(with event: NSEvent) {
-        let shouldSelect = !isDragging
-        if isDragging {
-            onDragEnded?(event)
-        }
-        isDragging = false
-        mouseDownLocation = nil
-        if shouldSelect {
-            onSelect?()
+        while let nextEvent = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
+            switch nextEvent.type {
+            case .leftMouseDragged:
+                let location = nextEvent.locationInWindow
+                if !isDragging && hypot(location.x - start.x, location.y - start.y) > 4 {
+                    isDragging = true
+                }
+                if isDragging {
+                    onDragMoved?(nextEvent)
+                }
+            case .leftMouseUp:
+                if isDragging {
+                    onDragEnded?(nextEvent)
+                } else {
+                    onSelect?()
+                }
+                return
+            default:
+                break
+            }
         }
     }
 

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -853,6 +853,9 @@ fileprivate final class SidebarTabRow: NSView {
     var onDragMoved: ((NSEvent) -> Void)?
     var onDragEnded: ((NSEvent) -> Void)?
     var onRightClick: ((NSPoint) -> Void)?
+    private var isDragging = false
+    private var mouseDownLocation: NSPoint?
+
     override var mouseDownCanMoveWindow: Bool { false }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
@@ -983,30 +986,30 @@ fileprivate final class SidebarTabRow: NSView {
     override func mouseDown(with event: NSEvent) {
         let loc = convert(event.locationInWindow, from: nil)
         if closeButton.frame.contains(loc) { onClose?(); return }
+        mouseDownLocation = event.locationInWindow
+        isDragging = false
+    }
 
-        let start = event.locationInWindow
-        var isDragging = false
+    override func mouseDragged(with event: NSEvent) {
+        guard let start = mouseDownLocation else { return }
+        let location = event.locationInWindow
+        if !isDragging && hypot(location.x - start.x, location.y - start.y) > 4 {
+            isDragging = true
+        }
+        if isDragging {
+            onDragMoved?(event)
+        }
+    }
 
-        while let nextEvent = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
-            switch nextEvent.type {
-            case .leftMouseDragged:
-                let location = nextEvent.locationInWindow
-                if !isDragging && hypot(location.x - start.x, location.y - start.y) > 4 {
-                    isDragging = true
-                }
-                if isDragging {
-                    onDragMoved?(nextEvent)
-                }
-            case .leftMouseUp:
-                if isDragging {
-                    onDragEnded?(nextEvent)
-                } else {
-                    onSelect?()
-                }
-                return
-            default:
-                break
-            }
+    override func mouseUp(with event: NSEvent) {
+        let shouldSelect = !isDragging
+        if isDragging {
+            onDragEnded?(event)
+        }
+        isDragging = false
+        mouseDownLocation = nil
+        if shouldSelect {
+            onSelect?()
         }
     }
 

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -269,13 +269,9 @@ final class SidebarView: NSView, NSDraggingSource {
             )
             row.onSelect = { [weak self] in self?.onSelectTab?(sourceIndex) }
             row.onClose = { [weak self] in self?.onCloseTab?(sourceIndex) }
-            row.onDragMoved = { [weak self, weak row] event in
-                guard let self, let row else { return }
-                self.handleLocalDragMoved(fromVisibleIndex: visibleIndex, event: event, dragView: row)
-            }
-            row.onDragEnded = { [weak self] event in
-                self?.handleLocalDragEnded(fromVisibleIndex: visibleIndex, event: event)
-            }
+            row.onDragBegan = { [weak self] in self?.beginDrag(fromIndex: visibleIndex) }
+            row.onDragMoved = { [weak self] loc in self?.updateDrag(location: loc) }
+            row.onDragEnded = { [weak self] in self?.endDrag() }
             row.onRightClick = { [weak self] point in self?.onTabContextMenu?(sourceIndex, point) }
             addSubview(row)
             tabRows.append(row)
@@ -523,44 +519,65 @@ final class SidebarView: NSView, NSDraggingSource {
 
     // MARK: - Tab Dragging
 
-    private func beginDragSession(fromVisibleIndex visibleIndex: Int, event: NSEvent, dragView: NSView) {
-        guard dragSourceIndex == nil,
-              visibleIndex >= 0, visibleIndex < tabRows.count,
-              let windowIdentifier = effectiveWindowIdentifier,
-              let draggingImage = dragImage(for: dragView) else { return }
-
-        let sourceTabIndex = tabRowSourceIndices[visibleIndex]
-        let payload = TabDragPayload(sourceWindowID: windowIdentifier, tabID: tabs[sourceTabIndex].id)
-        let pasteboardItem = NSPasteboardItem()
-        payload.set(on: pasteboardItem)
-
-        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
-        draggingItem.setDraggingFrame(dragView.bounds, contents: draggingImage)
-
-        dragSourceIndex = visibleIndex
-        localDragSourceVisibleIndex = nil
-        dragInsertionIndex = nil
-        isDropAccepted = false
-        ensureDragIndicator()
-        dragIndicatorLayer?.isHidden = true
-
-        let session = dragView.beginDraggingSession(with: [draggingItem], event: event, source: self)
-        session.animatesToStartingPositionsOnCancelOrFail = false
-        session.draggingFormation = .none
+    private func beginDrag(fromIndex: Int) {
+        dragSourceIndex = fromIndex
+        if dragIndicatorLayer == nil {
+            let indicator = CALayer()
+            indicator.backgroundColor = Theme.accent.withAlphaComponent(0.5).cgColor
+            indicator.cornerRadius = 1
+            layer?.addSublayer(indicator)
+            dragIndicatorLayer = indicator
+        }
     }
 
-    private func dragImage(for view: NSView) -> NSImage? {
-        guard view.bounds.width > 0, view.bounds.height > 0 else { return nil }
+    private func updateDrag(location: NSPoint) {
+        guard let sourceIdx = dragSourceIndex else { return }
+        let loc = convert(location, from: nil)
 
-        if let representation = view.bitmapImageRepForCachingDisplay(in: view.bounds) {
-            view.cacheDisplay(in: view.bounds, to: representation)
-            let image = NSImage(size: view.bounds.size)
-            image.addRepresentation(representation)
-            return image
+        var targetIdx: Int?
+        for (index, row) in tabRows.enumerated() {
+            if loc.y >= row.frame.minY && loc.y <= row.frame.maxY {
+                targetIdx = index
+                break
+            }
         }
 
-        let pdfData = view.dataWithPDF(inside: view.bounds)
-        return NSImage(data: pdfData)
+        if let target = targetIdx, target != sourceIdx {
+            let row = tabRows[target]
+            let indicatorY = target < sourceIdx ? row.frame.maxY + 1 : row.frame.minY - 2
+            dragIndicatorLayer?.frame = NSRect(x: row.frame.minX + 4, y: indicatorY, width: row.frame.width - 8, height: 2)
+            dragIndicatorLayer?.isHidden = false
+        } else {
+            dragIndicatorLayer?.isHidden = true
+        }
+    }
+
+    private func endDrag() {
+        guard let sourceIdx = dragSourceIndex else { return }
+        dragIndicatorLayer?.removeFromSuperlayer()
+        dragIndicatorLayer = nil
+
+        var targetIdx = sourceIdx
+
+        if let window {
+            let loc = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+            for (index, row) in tabRows.enumerated() {
+                if loc.y >= row.frame.minY && loc.y <= row.frame.maxY && index != sourceIdx {
+                    targetIdx = index
+                    break
+                }
+            }
+        }
+
+        dragSourceIndex = nil
+
+        if targetIdx != sourceIdx,
+           sourceIdx < tabRowSourceIndices.count,
+           targetIdx < tabRowSourceIndices.count {
+            let sourceTabIndex = tabRowSourceIndices[sourceIdx]
+            let targetTabIndex = tabRowSourceIndices[targetIdx]
+            onReorderTab?(sourceTabIndex, targetTabIndex)
+        }
     }
 
     private func ensureDragIndicator() {
@@ -604,48 +621,6 @@ final class SidebarView: NSView, NSDraggingSource {
             return min((tabRowSourceIndices.last ?? -1) + 1, tabs.count)
         }
         return tabRowSourceIndices[clampedVisibleIndex]
-    }
-
-    private func handleLocalDragMoved(fromVisibleIndex visibleIndex: Int, event: NSEvent, dragView: NSView) {
-        let location = convert(event.locationInWindow, from: nil)
-
-        if dragSourceIndex != nil {
-            return
-        }
-
-        if localDragSourceVisibleIndex == nil {
-            localDragSourceVisibleIndex = visibleIndex
-            ensureDragIndicator()
-        }
-
-        if !bounds.insetBy(dx: -12, dy: -8).contains(location) {
-            beginDragSession(fromVisibleIndex: visibleIndex, event: event, dragView: dragView)
-            return
-        }
-
-        dragInsertionIndex = visibleInsertionIndex(for: location)
-        updateDragIndicatorFrame()
-    }
-
-    private func handleLocalDragEnded(fromVisibleIndex visibleIndex: Int, event: NSEvent) {
-        guard dragSourceIndex == nil else { return }
-        defer { clearDragState() }
-
-        guard localDragSourceVisibleIndex == visibleIndex else { return }
-
-        let location = convert(event.locationInWindow, from: nil)
-        let visibleInsertionIndex = dragInsertionIndex ?? visibleInsertionIndex(for: location)
-        let requestedInsertionIndex = sourceInsertionIndex(forVisibleInsertionIndex: visibleInsertionIndex)
-        let sourceTabIndex = tabRowSourceIndices[visibleIndex]
-        let destinationIndex = Self.reorderDestinationIndex(
-            sourceIndex: sourceTabIndex,
-            insertionIndex: requestedInsertionIndex,
-            tabCount: tabs.count
-        )
-
-        if destinationIndex != sourceTabIndex {
-            onReorderTab?(sourceTabIndex, destinationIndex)
-        }
     }
 
     private func updateDragIndicatorFrame() {
@@ -737,8 +712,8 @@ final class SidebarView: NSView, NSDraggingSource {
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         guard let payload = TabDragPayload.read(from: sender.draggingPasteboard) else { return false }
-        let visibleInsertionIndex = dragInsertionIndex ?? visibleInsertionIndex(for: convert(sender.draggingLocation, from: nil))
-        let requestedInsertionIndex = sourceInsertionIndex(forVisibleInsertionIndex: visibleInsertionIndex)
+        let dropVisibleInsertionIndex = dragInsertionIndex ?? visibleInsertionIndex(for: convert(sender.draggingLocation, from: nil))
+        let requestedInsertionIndex = sourceInsertionIndex(forVisibleInsertionIndex: dropVisibleInsertionIndex)
         let sourceTabIndex = tabs.firstIndex(where: { $0.id == payload.tabID })
 
         if payload.sourceWindowID == effectiveWindowIdentifier, let sourceTabIndex {
@@ -850,23 +825,14 @@ final class SidebarView: NSView, NSDraggingSource {
 fileprivate final class SidebarTabRow: NSView {
     var onSelect: (() -> Void)?
     var onClose: (() -> Void)?
-    var onDragMoved: ((NSEvent) -> Void)?
-    var onDragEnded: ((NSEvent) -> Void)?
+    var onDragBegan: (() -> Void)?
+    var onDragMoved: ((NSPoint) -> Void)?
+    var onDragEnded: (() -> Void)?
     var onRightClick: ((NSPoint) -> Void)?
     private var isDragging = false
     private var mouseDownLocation: NSPoint?
 
     override var mouseDownCanMoveWindow: Bool { false }
-
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
-
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        guard bounds.contains(point) else { return nil }
-        if closeButton.frame.contains(point) {
-            return closeButton
-        }
-        return self
-    }
 
     private let selectionIndicator = CALayer()
     private let iconPlate = CALayer()
@@ -988,29 +954,23 @@ fileprivate final class SidebarTabRow: NSView {
         if closeButton.frame.contains(loc) { onClose?(); return }
         mouseDownLocation = event.locationInWindow
         isDragging = false
+        onSelect?()
     }
 
     override func mouseDragged(with event: NSEvent) {
         guard let start = mouseDownLocation else { return }
-        let location = event.locationInWindow
-        if !isDragging && hypot(location.x - start.x, location.y - start.y) > 4 {
+        let loc = event.locationInWindow
+        if !isDragging && hypot(loc.x - start.x, loc.y - start.y) > 4 {
             isDragging = true
+            onDragBegan?()
         }
-        if isDragging {
-            onDragMoved?(event)
-        }
+        if isDragging { onDragMoved?(event.locationInWindow) }
     }
 
     override func mouseUp(with event: NSEvent) {
-        let shouldSelect = !isDragging
-        if isDragging {
-            onDragEnded?(event)
-        }
+        if isDragging { onDragEnded?() }
         isDragging = false
         mouseDownLocation = nil
-        if shouldSelect {
-            onSelect?()
-        }
     }
 
     override func rightMouseDown(with event: NSEvent) { onRightClick?(event.locationInWindow) }

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -2,7 +2,7 @@ import AppKit
 import QuartzCore
 
 /// Monochrome utility sidebar with restrained chrome and strong type hierarchy.
-final class SidebarView: NSView {
+final class SidebarView: NSView, NSDraggingSource {
     typealias TabModel = (id: UUID, title: String, kind: TerminalContainerView.TabKind)
 
     struct SettingsSnapshot: Equatable {
@@ -61,6 +61,10 @@ final class SidebarView: NSView {
     var onExpandChanged: ((Bool) -> Void)?
     var onReorderTab: ((Int, Int) -> Void)?
     var onTabContextMenu: ((Int, NSPoint) -> Void)?
+    var onReceiveDraggedTab: ((TabDragPayload, Int) -> Void)?
+    var onTearOffTab: ((UUID, NSPoint) -> Void)?
+
+    var windowIdentifier: UUID?
 
     /// Called when a tool is clicked in the sidebar. The container opens it in the main content area.
     var onSelectTool: ((String) -> Void)?
@@ -68,6 +72,8 @@ final class SidebarView: NSView {
     private var newTabTrackingArea: NSTrackingArea?
     private var dragSourceIndex: Int?
     private var dragIndicatorLayer: CALayer?
+    private var dragInsertionIndex: Int?
+    private var isDropAccepted = false
     private let pinButton = NSButton()
     private var settingsObserver: NSObjectProtocol?
 
@@ -81,6 +87,7 @@ final class SidebarView: NSView {
         self.isPinned = settings.sidebarPinned
         self.settingsSnapshot = SettingsSnapshot.current(using: settings)
         super.init(frame: frameRect)
+        registerForDraggedTypes([TabDragPayload.pasteboardType])
         wantsLayer = true
         alphaValue = 1
         appearance = Theme.overlayAppearance
@@ -256,9 +263,10 @@ final class SidebarView: NSView {
             )
             row.onSelect = { [weak self] in self?.onSelectTab?(sourceIndex) }
             row.onClose = { [weak self] in self?.onCloseTab?(sourceIndex) }
-            row.onDragBegan = { [weak self] in self?.beginDrag(fromIndex: visibleIndex) }
-            row.onDragMoved = { [weak self] loc in self?.updateDrag(location: loc) }
-            row.onDragEnded = { [weak self] in self?.endDrag() }
+            row.onBeginDrag = { [weak self, weak row] event in
+                guard let self, let row else { return }
+                self.beginDragSession(fromVisibleIndex: visibleIndex, event: event, dragView: row)
+            }
             row.onRightClick = { [weak self] point in self?.onTabContextMenu?(sourceIndex, point) }
             addSubview(row)
             tabRows.append(row)
@@ -504,67 +512,199 @@ final class SidebarView: NSView {
         }
     }
 
-    // MARK: - Tab Reordering
+    // MARK: - Tab Dragging
 
-    private func beginDrag(fromIndex: Int) {
-        dragSourceIndex = fromIndex
-        if dragIndicatorLayer == nil {
-            let indicator = CALayer()
-            indicator.backgroundColor = Theme.accent.withAlphaComponent(0.5).cgColor
-            indicator.cornerRadius = 1
-            layer?.addSublayer(indicator)
-            dragIndicatorLayer = indicator
-        }
+    private func beginDragSession(fromVisibleIndex visibleIndex: Int, event: NSEvent, dragView: NSView) {
+        guard dragSourceIndex == nil,
+              visibleIndex >= 0, visibleIndex < tabRows.count,
+              let windowIdentifier,
+              let draggingImage = dragImage(for: dragView) else { return }
+
+        let sourceTabIndex = tabRowSourceIndices[visibleIndex]
+        let payload = TabDragPayload(sourceWindowID: windowIdentifier, tabID: tabs[sourceTabIndex].id)
+        let pasteboardItem = NSPasteboardItem()
+        payload.set(on: pasteboardItem)
+
+        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+        draggingItem.setDraggingFrame(convert(dragView.bounds, from: dragView), contents: draggingImage)
+
+        dragSourceIndex = visibleIndex
+        dragInsertionIndex = nil
+        isDropAccepted = false
+        ensureDragIndicator()
+        dragIndicatorLayer?.isHidden = true
+
+        let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
+        session.animatesToStartingPositionsOnCancelOrFail = false
+        session.draggingFormation = .none
     }
 
-    private func updateDrag(location: NSPoint) {
-        guard let sourceIdx = dragSourceIndex else { return }
-        let loc = convert(location, from: nil)
-
-        var targetIdx: Int?
-        for (i, row) in tabRows.enumerated() {
-            if loc.y >= row.frame.minY && loc.y <= row.frame.maxY {
-                targetIdx = i
-                break
-            }
+    private func dragImage(for view: NSView) -> NSImage? {
+        guard view.bounds.width > 0, view.bounds.height > 0,
+              let representation = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+            return nil
         }
-
-        if let target = targetIdx, target != sourceIdx {
-            let row = tabRows[target]
-            let indicatorY = target < sourceIdx ? row.frame.maxY + 1 : row.frame.minY - 2
-            dragIndicatorLayer?.frame = NSRect(x: row.frame.minX + 4, y: indicatorY, width: row.frame.width - 8, height: 2)
-            dragIndicatorLayer?.isHidden = false
-        } else {
-            dragIndicatorLayer?.isHidden = true
-        }
+        view.cacheDisplay(in: view.bounds, to: representation)
+        let image = NSImage(size: view.bounds.size)
+        image.addRepresentation(representation)
+        return image
     }
 
-    private func endDrag() {
-        guard let sourceIdx = dragSourceIndex else { return }
+    private func ensureDragIndicator() {
+        guard dragIndicatorLayer == nil else { return }
+        let indicator = CALayer()
+        indicator.backgroundColor = Theme.accent.withAlphaComponent(0.5).cgColor
+        indicator.cornerRadius = 1
+        layer?.addSublayer(indicator)
+        dragIndicatorLayer = indicator
+    }
+
+    private func clearDragState() {
+        dragSourceIndex = nil
+        dragInsertionIndex = nil
+        isDropAccepted = false
         dragIndicatorLayer?.removeFromSuperlayer()
         dragIndicatorLayer = nil
+    }
 
-        var targetIdx = sourceIdx
+    private func visibleInsertionIndex(for location: NSPoint) -> Int {
+        guard !tabRows.isEmpty else { return 0 }
 
-        if let window = window {
-            let loc = convert(window.mouseLocationOutsideOfEventStream, from: nil)
-            for (i, row) in tabRows.enumerated() {
-                if loc.y >= row.frame.minY && loc.y <= row.frame.maxY && i != sourceIdx {
-                    targetIdx = i
-                    break
-                }
+        for (index, row) in tabRows.enumerated() {
+            if location.y > row.frame.midY {
+                return index
             }
         }
 
-        dragSourceIndex = nil
+        return tabRows.count
+    }
 
-        if targetIdx != sourceIdx,
-           sourceIdx < tabRowSourceIndices.count,
-           targetIdx < tabRowSourceIndices.count {
-            let sourceTabIndex = tabRowSourceIndices[sourceIdx]
-            let targetTabIndex = tabRowSourceIndices[targetIdx]
-            onReorderTab?(sourceTabIndex, targetTabIndex)
+    func sourceInsertionIndex(forVisibleInsertionIndex visibleInsertionIndex: Int) -> Int {
+        guard !tabRowSourceIndices.isEmpty else { return 0 }
+        let clampedVisibleIndex = max(0, min(visibleInsertionIndex, tabRowSourceIndices.count))
+
+        if clampedVisibleIndex <= 0 {
+            return tabRowSourceIndices[0]
         }
+        if clampedVisibleIndex >= tabRowSourceIndices.count {
+            return min((tabRowSourceIndices.last ?? -1) + 1, tabs.count)
+        }
+        return tabRowSourceIndices[clampedVisibleIndex]
+    }
+
+    private func updateDragIndicatorFrame() {
+        guard let dragIndicatorLayer,
+              let dragInsertionIndex else {
+            self.dragIndicatorLayer?.isHidden = true
+            return
+        }
+
+        let indicatorX = 18.0
+        let indicatorWidth = max(0, bounds.width - 36)
+        let indicatorY: CGFloat
+        if tabRows.isEmpty {
+            indicatorY = headerLabel.frame.minY - 24
+        } else if dragInsertionIndex <= 0 {
+            indicatorY = tabRows[0].frame.maxY + 2
+        } else if dragInsertionIndex >= tabRows.count {
+            indicatorY = tabRows[tabRows.count - 1].frame.minY - 3
+        } else {
+            indicatorY = tabRows[dragInsertionIndex].frame.maxY + 2
+        }
+
+        dragIndicatorLayer.frame = NSRect(x: indicatorX, y: indicatorY, width: indicatorWidth, height: 2)
+        dragIndicatorLayer.isHidden = false
+    }
+
+    static func reorderDestinationIndex(sourceIndex: Int, insertionIndex: Int, tabCount: Int) -> Int {
+        guard tabCount > 0 else { return 0 }
+        let clampedInsertion = max(0, min(insertionIndex, tabCount))
+        let adjustedIndex = clampedInsertion > sourceIndex ? clampedInsertion - 1 : clampedInsertion
+        return max(0, min(adjustedIndex, tabCount - 1))
+    }
+
+    // MARK: - NSDraggingSource
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        .move
+    }
+
+    func ignoreModifierKeys(for session: NSDraggingSession) -> Bool {
+        true
+    }
+
+    func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
+        let tabID: UUID?
+        if let dragSourceIndex, dragSourceIndex < tabRowSourceIndices.count {
+            let sourceTabIndex = tabRowSourceIndices[dragSourceIndex]
+            tabID = tabs.indices.contains(sourceTabIndex) ? tabs[sourceTabIndex].id : nil
+        } else {
+            tabID = nil
+        }
+        let shouldTearOff = operation == [] && !isDropAccepted
+        clearDragState()
+
+        guard shouldTearOff, let tabID else { return }
+        onTearOffTab?(tabID, screenPoint)
+    }
+
+    // MARK: - NSDraggingDestination
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        draggingUpdated(sender)
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard TabDragPayload.read(from: sender.draggingPasteboard) != nil else {
+            dragInsertionIndex = nil
+            updateDragIndicatorFrame()
+            return []
+        }
+
+        ensureDragIndicator()
+        dragInsertionIndex = visibleInsertionIndex(for: convert(sender.draggingLocation, from: nil))
+        updateDragIndicatorFrame()
+        return .move
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        dragInsertionIndex = nil
+        updateDragIndicatorFrame()
+    }
+
+    override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        TabDragPayload.read(from: sender.draggingPasteboard) != nil
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let payload = TabDragPayload.read(from: sender.draggingPasteboard) else { return false }
+        let visibleInsertionIndex = dragInsertionIndex ?? visibleInsertionIndex(for: convert(sender.draggingLocation, from: nil))
+        let requestedInsertionIndex = sourceInsertionIndex(forVisibleInsertionIndex: visibleInsertionIndex)
+        let sourceTabIndex = tabs.firstIndex(where: { $0.id == payload.tabID })
+
+        if payload.sourceWindowID == windowIdentifier, let sourceTabIndex {
+            let destinationIndex = Self.reorderDestinationIndex(
+                sourceIndex: sourceTabIndex,
+                insertionIndex: requestedInsertionIndex,
+                tabCount: tabs.count
+            )
+            if destinationIndex != sourceTabIndex {
+                onReorderTab?(sourceTabIndex, destinationIndex)
+            }
+        } else {
+            onReceiveDraggedTab?(payload, requestedInsertionIndex)
+        }
+
+        isDropAccepted = true
+        return true
+    }
+
+    override func concludeDragOperation(_ sender: NSDraggingInfo?) {
+        dragInsertionIndex = nil
+        updateDragIndicatorFrame()
     }
 
     // MARK: - Show / Hide
@@ -654,9 +794,7 @@ final class SidebarView: NSView {
 fileprivate final class SidebarTabRow: NSView {
     var onSelect: (() -> Void)?
     var onClose: (() -> Void)?
-    var onDragBegan: (() -> Void)?
-    var onDragMoved: ((NSPoint) -> Void)?
-    var onDragEnded: (() -> Void)?
+    var onBeginDrag: ((NSEvent) -> Void)?
     var onRightClick: ((NSPoint) -> Void)?
     private var isDragging = false
     private var mouseDownLocation: NSPoint?
@@ -791,13 +929,11 @@ fileprivate final class SidebarTabRow: NSView {
         let loc = event.locationInWindow
         if !isDragging && hypot(loc.x - start.x, loc.y - start.y) > 4 {
             isDragging = true
-            onDragBegan?()
+            onBeginDrag?(event)
         }
-        if isDragging { onDragMoved?(event.locationInWindow) }
     }
 
     override func mouseUp(with event: NSEvent) {
-        if isDragging { onDragEnded?() }
         isDragging = false
         mouseDownLocation = nil
     }

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -269,9 +269,13 @@ final class SidebarView: NSView, NSDraggingSource {
             )
             row.onSelect = { [weak self] in self?.onSelectTab?(sourceIndex) }
             row.onClose = { [weak self] in self?.onCloseTab?(sourceIndex) }
-            row.onDragBegan = { [weak self] in self?.beginDrag(fromIndex: visibleIndex) }
-            row.onDragMoved = { [weak self] loc in self?.updateDrag(location: loc) }
-            row.onDragEnded = { [weak self] in self?.endDrag() }
+            row.onDragMoved = { [weak self, weak row] event in
+                guard let self, let row else { return }
+                self.handleLocalDragMoved(fromVisibleIndex: visibleIndex, event: event, dragView: row)
+            }
+            row.onDragEnded = { [weak self] event in
+                self?.handleLocalDragEnded(fromVisibleIndex: visibleIndex, event: event)
+            }
             row.onRightClick = { [weak self] point in self?.onTabContextMenu?(sourceIndex, point) }
             addSubview(row)
             tabRows.append(row)
@@ -519,64 +523,88 @@ final class SidebarView: NSView, NSDraggingSource {
 
     // MARK: - Tab Dragging
 
-    private func beginDrag(fromIndex: Int) {
-        dragSourceIndex = fromIndex
-        if dragIndicatorLayer == nil {
-            let indicator = CALayer()
-            indicator.backgroundColor = Theme.accent.withAlphaComponent(0.5).cgColor
-            indicator.cornerRadius = 1
-            layer?.addSublayer(indicator)
-            dragIndicatorLayer = indicator
-        }
+    private func beginDragSession(fromVisibleIndex visibleIndex: Int, event: NSEvent, dragView: NSView) {
+        guard dragSourceIndex == nil,
+              visibleIndex >= 0, visibleIndex < tabRowSourceIndices.count,
+              let windowIdentifier = effectiveWindowIdentifier else { return }
+
+        let sourceTabIndex = tabRowSourceIndices[visibleIndex]
+        guard tabs.indices.contains(sourceTabIndex),
+              let draggingImage = dragImage(for: dragView) else { return }
+
+        let payload = TabDragPayload(sourceWindowID: windowIdentifier, tabID: tabs[sourceTabIndex].id)
+        let pasteboardItem = NSPasteboardItem()
+        payload.set(on: pasteboardItem)
+
+        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+        draggingItem.setDraggingFrame(dragView.bounds, contents: draggingImage)
+
+        dragSourceIndex = visibleIndex
+        localDragSourceVisibleIndex = nil
+        dragInsertionIndex = nil
+        isDropAccepted = false
+        ensureDragIndicator()
+        dragIndicatorLayer?.isHidden = true
+
+        let session = dragView.beginDraggingSession(with: [draggingItem], event: event, source: self)
+        session.animatesToStartingPositionsOnCancelOrFail = false
+        session.draggingFormation = .none
     }
 
-    private func updateDrag(location: NSPoint) {
-        guard let sourceIdx = dragSourceIndex else { return }
-        let loc = convert(location, from: nil)
+    private func dragImage(for view: NSView) -> NSImage? {
+        guard view.bounds.width > 0, view.bounds.height > 0 else { return nil }
 
-        var targetIdx: Int?
-        for (index, row) in tabRows.enumerated() {
-            if loc.y >= row.frame.minY && loc.y <= row.frame.maxY {
-                targetIdx = index
-                break
-            }
+        if let representation = view.bitmapImageRepForCachingDisplay(in: view.bounds) {
+            view.cacheDisplay(in: view.bounds, to: representation)
+            let image = NSImage(size: view.bounds.size)
+            image.addRepresentation(representation)
+            return image
         }
 
-        if let target = targetIdx, target != sourceIdx {
-            let row = tabRows[target]
-            let indicatorY = target < sourceIdx ? row.frame.maxY + 1 : row.frame.minY - 2
-            dragIndicatorLayer?.frame = NSRect(x: row.frame.minX + 4, y: indicatorY, width: row.frame.width - 8, height: 2)
-            dragIndicatorLayer?.isHidden = false
-        } else {
-            dragIndicatorLayer?.isHidden = true
-        }
+        let pdfData = view.dataWithPDF(inside: view.bounds)
+        return NSImage(data: pdfData)
     }
 
-    private func endDrag() {
-        guard let sourceIdx = dragSourceIndex else { return }
-        dragIndicatorLayer?.removeFromSuperlayer()
-        dragIndicatorLayer = nil
+    private func handleLocalDragMoved(fromVisibleIndex visibleIndex: Int, event: NSEvent, dragView: NSView) {
+        // Once a system drag session starts, NSDraggingSource owns the lifecycle.
+        if dragSourceIndex != nil { return }
 
-        var targetIdx = sourceIdx
+        let location = convert(event.locationInWindow, from: nil)
 
-        if let window {
-            let loc = convert(window.mouseLocationOutsideOfEventStream, from: nil)
-            for (index, row) in tabRows.enumerated() {
-                if loc.y >= row.frame.minY && loc.y <= row.frame.maxY && index != sourceIdx {
-                    targetIdx = index
-                    break
-                }
-            }
+        if localDragSourceVisibleIndex == nil {
+            localDragSourceVisibleIndex = visibleIndex
+            ensureDragIndicator()
         }
 
-        dragSourceIndex = nil
+        if !bounds.insetBy(dx: -12, dy: -8).contains(location) {
+            beginDragSession(fromVisibleIndex: visibleIndex, event: event, dragView: dragView)
+            return
+        }
 
-        if targetIdx != sourceIdx,
-           sourceIdx < tabRowSourceIndices.count,
-           targetIdx < tabRowSourceIndices.count {
-            let sourceTabIndex = tabRowSourceIndices[sourceIdx]
-            let targetTabIndex = tabRowSourceIndices[targetIdx]
-            onReorderTab?(sourceTabIndex, targetTabIndex)
+        dragInsertionIndex = visibleInsertionIndex(for: location)
+        updateDragIndicatorFrame()
+    }
+
+    private func handleLocalDragEnded(fromVisibleIndex visibleIndex: Int, event: NSEvent) {
+        // System drag session already running — let NSDraggingSource finish it.
+        guard dragSourceIndex == nil else { return }
+        defer { clearDragState() }
+
+        guard localDragSourceVisibleIndex == visibleIndex,
+              visibleIndex < tabRowSourceIndices.count else { return }
+
+        let location = convert(event.locationInWindow, from: nil)
+        let insertion = dragInsertionIndex ?? visibleInsertionIndex(for: location)
+        let requestedInsertionIndex = sourceInsertionIndex(forVisibleInsertionIndex: insertion)
+        let sourceTabIndex = tabRowSourceIndices[visibleIndex]
+        let destinationIndex = Self.reorderDestinationIndex(
+            sourceIndex: sourceTabIndex,
+            insertionIndex: requestedInsertionIndex,
+            tabCount: tabs.count
+        )
+
+        if destinationIndex != sourceTabIndex {
+            onReorderTab?(sourceTabIndex, destinationIndex)
         }
     }
 
@@ -825,9 +853,8 @@ final class SidebarView: NSView, NSDraggingSource {
 fileprivate final class SidebarTabRow: NSView {
     var onSelect: (() -> Void)?
     var onClose: (() -> Void)?
-    var onDragBegan: (() -> Void)?
-    var onDragMoved: ((NSPoint) -> Void)?
-    var onDragEnded: (() -> Void)?
+    var onDragMoved: ((NSEvent) -> Void)?
+    var onDragEnded: ((NSEvent) -> Void)?
     var onRightClick: ((NSPoint) -> Void)?
     private var isDragging = false
     private var mouseDownLocation: NSPoint?
@@ -954,7 +981,6 @@ fileprivate final class SidebarTabRow: NSView {
         if closeButton.frame.contains(loc) { onClose?(); return }
         mouseDownLocation = event.locationInWindow
         isDragging = false
-        onSelect?()
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -962,15 +988,17 @@ fileprivate final class SidebarTabRow: NSView {
         let loc = event.locationInWindow
         if !isDragging && hypot(loc.x - start.x, loc.y - start.y) > 4 {
             isDragging = true
-            onDragBegan?()
         }
-        if isDragging { onDragMoved?(event.locationInWindow) }
+        if isDragging { onDragMoved?(event) }
     }
 
     override func mouseUp(with event: NSEvent) {
-        if isDragging { onDragEnded?() }
+        let shouldSelect = !isDragging
+        if isDragging { onDragEnded?(event) }
         isDragging = false
         mouseDownLocation = nil
+        // Fire selection after drag handling so refreshTabUI doesn't rebuild the row mid-interaction.
+        if shouldSelect { onSelect?() }
     }
 
     override func rightMouseDown(with event: NSEvent) { onRightClick?(event.locationInWindow) }

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -76,6 +76,7 @@ final class SidebarView: NSView, NSDraggingSource {
 
     private var newTabTrackingArea: NSTrackingArea?
     private var dragSourceIndex: Int?
+    private var localDragSourceVisibleIndex: Int?
     private var dragIndicatorLayer: CALayer?
     private var dragInsertionIndex: Int?
     private var isDropAccepted = false
@@ -268,9 +269,12 @@ final class SidebarView: NSView, NSDraggingSource {
             )
             row.onSelect = { [weak self] in self?.onSelectTab?(sourceIndex) }
             row.onClose = { [weak self] in self?.onCloseTab?(sourceIndex) }
-            row.onBeginDrag = { [weak self, weak row] event in
+            row.onDragMoved = { [weak self, weak row] event in
                 guard let self, let row else { return }
-                self.beginDragSession(fromVisibleIndex: visibleIndex, event: event, dragView: row)
+                self.handleLocalDragMoved(fromVisibleIndex: visibleIndex, event: event, dragView: row)
+            }
+            row.onDragEnded = { [weak self] event in
+                self?.handleLocalDragEnded(fromVisibleIndex: visibleIndex, event: event)
             }
             row.onRightClick = { [weak self] point in self?.onTabContextMenu?(sourceIndex, point) }
             addSubview(row)
@@ -534,6 +538,7 @@ final class SidebarView: NSView, NSDraggingSource {
         draggingItem.setDraggingFrame(dragView.bounds, contents: draggingImage)
 
         dragSourceIndex = visibleIndex
+        localDragSourceVisibleIndex = nil
         dragInsertionIndex = nil
         isDropAccepted = false
         ensureDragIndicator()
@@ -569,6 +574,7 @@ final class SidebarView: NSView, NSDraggingSource {
 
     private func clearDragState() {
         dragSourceIndex = nil
+        localDragSourceVisibleIndex = nil
         dragInsertionIndex = nil
         isDropAccepted = false
         dragIndicatorLayer?.removeFromSuperlayer()
@@ -598,6 +604,48 @@ final class SidebarView: NSView, NSDraggingSource {
             return min((tabRowSourceIndices.last ?? -1) + 1, tabs.count)
         }
         return tabRowSourceIndices[clampedVisibleIndex]
+    }
+
+    private func handleLocalDragMoved(fromVisibleIndex visibleIndex: Int, event: NSEvent, dragView: NSView) {
+        let location = convert(event.locationInWindow, from: nil)
+
+        if dragSourceIndex != nil {
+            return
+        }
+
+        if localDragSourceVisibleIndex == nil {
+            localDragSourceVisibleIndex = visibleIndex
+            ensureDragIndicator()
+        }
+
+        if !bounds.insetBy(dx: -12, dy: -8).contains(location) {
+            beginDragSession(fromVisibleIndex: visibleIndex, event: event, dragView: dragView)
+            return
+        }
+
+        dragInsertionIndex = visibleInsertionIndex(for: location)
+        updateDragIndicatorFrame()
+    }
+
+    private func handleLocalDragEnded(fromVisibleIndex visibleIndex: Int, event: NSEvent) {
+        guard dragSourceIndex == nil else { return }
+        defer { clearDragState() }
+
+        guard localDragSourceVisibleIndex == visibleIndex else { return }
+
+        let location = convert(event.locationInWindow, from: nil)
+        let visibleInsertionIndex = dragInsertionIndex ?? visibleInsertionIndex(for: location)
+        let requestedInsertionIndex = sourceInsertionIndex(forVisibleInsertionIndex: visibleInsertionIndex)
+        let sourceTabIndex = tabRowSourceIndices[visibleIndex]
+        let destinationIndex = Self.reorderDestinationIndex(
+            sourceIndex: sourceTabIndex,
+            insertionIndex: requestedInsertionIndex,
+            tabCount: tabs.count
+        )
+
+        if destinationIndex != sourceTabIndex {
+            onReorderTab?(sourceTabIndex, destinationIndex)
+        }
     }
 
     private func updateDragIndicatorFrame() {
@@ -802,7 +850,8 @@ final class SidebarView: NSView, NSDraggingSource {
 fileprivate final class SidebarTabRow: NSView {
     var onSelect: (() -> Void)?
     var onClose: (() -> Void)?
-    var onBeginDrag: ((NSEvent) -> Void)?
+    var onDragMoved: ((NSEvent) -> Void)?
+    var onDragEnded: ((NSEvent) -> Void)?
     var onRightClick: ((NSPoint) -> Void)?
     private var isDragging = false
     private var mouseDownLocation: NSPoint?
@@ -946,12 +995,17 @@ fileprivate final class SidebarTabRow: NSView {
         let loc = event.locationInWindow
         if !isDragging && hypot(loc.x - start.x, loc.y - start.y) > 4 {
             isDragging = true
-            onBeginDrag?(event)
+        }
+        if isDragging {
+            onDragMoved?(event)
         }
     }
 
     override func mouseUp(with event: NSEvent) {
         let shouldSelect = !isDragging
+        if isDragging {
+            onDragEnded?(event)
+        }
         isDragging = false
         mouseDownLocation = nil
         if shouldSelect {

--- a/Bellith/Views/SidebarView.swift
+++ b/Bellith/Views/SidebarView.swift
@@ -929,7 +929,6 @@ fileprivate final class SidebarTabRow: NSView {
         if closeButton.frame.contains(loc) { onClose?(); return }
         mouseDownLocation = event.locationInWindow
         isDragging = false
-        onSelect?()
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -942,8 +941,12 @@ fileprivate final class SidebarTabRow: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
+        let shouldSelect = !isDragging
         isDragging = false
         mouseDownLocation = nil
+        if shouldSelect {
+            onSelect?()
+        }
     }
 
     override func rightMouseDown(with event: NSEvent) { onRightClick?(event.locationInWindow) }

--- a/Bellith/Views/TabBarView.swift
+++ b/Bellith/Views/TabBarView.swift
@@ -37,6 +37,7 @@ final class TabBarView: NSView, NSDraggingSource {
     private var singleTabMouseDownLocation: NSPoint?
 
     override var mouseDownCanMoveWindow: Bool { false }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     init(frame frameRect: NSRect = .zero, smartPanelRegistry: SmartPanelRegistry = .shared) {
         self.smartPanelRegistry = smartPanelRegistry
@@ -214,7 +215,7 @@ final class TabBarView: NSView, NSDraggingSource {
         payload.set(on: pasteboardItem)
 
         let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
-        draggingItem.setDraggingFrame(convert(dragView.bounds, from: dragView), contents: draggingImage)
+        draggingItem.setDraggingFrame(dragView.bounds, contents: draggingImage)
 
         dragSourceIndex = fromIndex
         dragInsertionIndex = nil
@@ -222,20 +223,23 @@ final class TabBarView: NSView, NSDraggingSource {
         ensureDragIndicator()
         dragIndicatorLayer?.isHidden = true
 
-        let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
+        let session = dragView.beginDraggingSession(with: [draggingItem], event: event, source: self)
         session.animatesToStartingPositionsOnCancelOrFail = false
         session.draggingFormation = .none
     }
 
     private func dragImage(for view: NSView) -> NSImage? {
-        guard view.bounds.width > 0, view.bounds.height > 0,
-              let representation = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
-            return nil
+        guard view.bounds.width > 0, view.bounds.height > 0 else { return nil }
+
+        if let representation = view.bitmapImageRepForCachingDisplay(in: view.bounds) {
+            view.cacheDisplay(in: view.bounds, to: representation)
+            let image = NSImage(size: view.bounds.size)
+            image.addRepresentation(representation)
+            return image
         }
-        view.cacheDisplay(in: view.bounds, to: representation)
-        let image = NSImage(size: view.bounds.size)
-        image.addRepresentation(representation)
-        return image
+
+        let pdfData = view.dataWithPDF(inside: view.bounds)
+        return NSImage(data: pdfData)
     }
 
     private func ensureDragIndicator() {
@@ -400,6 +404,7 @@ fileprivate final class TabPillView: NSView {
     private var mouseDownLocation: NSPoint?
 
     override var mouseDownCanMoveWindow: Bool { false }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         guard bounds.contains(point) else { return nil }

--- a/Bellith/Views/TabBarView.swift
+++ b/Bellith/Views/TabBarView.swift
@@ -3,7 +3,7 @@ import AppKit
 /// Minimal Zen-style tab bar. Sits in the titlebar area, right of the traffic lights.
 /// Pill-shaped tabs, close button appears on hover only.
 /// Smart tabs show distinct icons and accent colors.
-final class TabBarView: NSView {
+final class TabBarView: NSView, NSDraggingSource {
     struct Tab {
         let id: UUID
         var title: String
@@ -20,19 +20,28 @@ final class TabBarView: NSView {
     var onNewTab: (() -> Void)?
     var onReorderTab: ((Int, Int) -> Void)?
     var onTogglePin: ((Int) -> Void)?
+    var onReceiveDraggedTab: ((TabDragPayload, Int) -> Void)?
+    var onTearOffTab: ((UUID, NSPoint) -> Void)?
+
+    var windowIdentifier: UUID?
 
     private var dragSourceIndex: Int?
-    private var dragTargetIndex: Int?
     private var dragIndicatorLayer: CALayer?
+    private var dragInsertionIndex: Int?
+    private var isDropAccepted = false
     private let smartPanelRegistry: SmartPanelRegistry
 
     private let newTabButton = NSButton()
     private let singleTabLabel = NSTextField(labelWithString: "")
     private var themeObserver: NSObjectProtocol?
+    private var singleTabMouseDownLocation: NSPoint?
+
+    override var mouseDownCanMoveWindow: Bool { false }
 
     init(frame frameRect: NSRect = .zero, smartPanelRegistry: SmartPanelRegistry = .shared) {
         self.smartPanelRegistry = smartPanelRegistry
         super.init(frame: frameRect)
+        registerForDraggedTypes([TabDragPayload.pasteboardType])
         setupNewTabButton()
         setupSingleTabLabel()
         themeObserver = NotificationCenter.default.addObserver(
@@ -110,9 +119,10 @@ final class TabBarView: NSView {
             pill.onSelect = { [weak self] in self?.onSelectTab?(i) }
             pill.onClose = { [weak self] in self?.onCloseTab?(i) }
             pill.onTogglePin = { [weak self] in self?.onTogglePin?(i) }
-            pill.onDragBegan = { [weak self] in self?.beginDrag(fromIndex: i) }
-            pill.onDragMoved = { [weak self] loc in self?.updateDrag(location: loc) }
-            pill.onDragEnded = { [weak self] in self?.endDrag() }
+            pill.onBeginDrag = { [weak self, weak pill] event in
+                guard let self else { return }
+                self.beginDragSession(fromIndex: i, event: event, dragView: pill)
+            }
             addSubview(pill)
             tabViews.append(pill)
         }
@@ -136,68 +146,238 @@ final class TabBarView: NSView {
 
         newTabButton.frame = NSRect(x: x + 4, y: (height - 24) / 2, width: 24, height: 24)
 
-        // Single tab: show just the label and new tab button, hide pills
+        // Single tab: show just the label and new tab button, hide pills.
         if tabs.count <= 1 {
             singleTabLabel.isHidden = false
-            singleTabLabel.frame = NSRect(x: 0, y: (height - 16) / 2, width: min(240, singleTabLabel.attributedStringValue.size().width + 8), height: 16)
+            singleTabLabel.frame = NSRect(
+                x: 0,
+                y: (height - 16) / 2,
+                width: min(240, singleTabLabel.attributedStringValue.size().width + 8),
+                height: 16
+            )
             newTabButton.frame = NSRect(x: singleTabLabel.frame.maxX + 8, y: (height - 24) / 2, width: 24, height: 24)
             tabViews.forEach { $0.isHidden = true }
         } else {
             singleTabLabel.isHidden = true
             tabViews.forEach { $0.isHidden = false }
         }
+
+        updateDragIndicatorFrame()
     }
 
-    // MARK: - Tab Reordering
-
-    private func beginDrag(fromIndex: Int) {
-        dragSourceIndex = fromIndex
-        dragTargetIndex = nil
-        if dragIndicatorLayer == nil {
-            let indicator = CALayer()
-            indicator.backgroundColor = Theme.accent.withAlphaComponent(0.5).cgColor
-            indicator.cornerRadius = 1
-            wantsLayer = true
-            layer?.addSublayer(indicator)
-            dragIndicatorLayer = indicator
+    override func mouseDown(with event: NSEvent) {
+        guard tabs.count == 1 else {
+            super.mouseDown(with: event)
+            return
         }
+
+        let location = convert(event.locationInWindow, from: nil)
+        guard singleTabLabel.frame.insetBy(dx: -4, dy: -4).contains(location) else {
+            super.mouseDown(with: event)
+            return
+        }
+
+        singleTabMouseDownLocation = event.locationInWindow
+        onSelectTab?(0)
     }
 
-    private func updateDrag(location: NSPoint) {
-        guard let sourceIdx = dragSourceIndex else { return }
-        let loc = convert(location, from: nil)
+    override func mouseDragged(with event: NSEvent) {
+        guard tabs.count == 1, let start = singleTabMouseDownLocation else {
+            super.mouseDragged(with: event)
+            return
+        }
 
-        var targetIdx: Int?
-        for (i, pill) in tabViews.enumerated() {
-            if loc.x >= pill.frame.minX && loc.x <= pill.frame.maxX {
-                targetIdx = i
-                break
+        let location = event.locationInWindow
+        guard hypot(location.x - start.x, location.y - start.y) > 4 else { return }
+        singleTabMouseDownLocation = nil
+        beginDragSession(fromIndex: 0, event: event, dragView: singleTabLabel)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        singleTabMouseDownLocation = nil
+        super.mouseUp(with: event)
+    }
+
+    private func beginDragSession(fromIndex: Int, event: NSEvent, dragView: NSView?) {
+        guard dragSourceIndex == nil,
+              fromIndex >= 0, fromIndex < tabs.count,
+              let windowIdentifier,
+              let dragView,
+              let draggingImage = dragImage(for: dragView) else { return }
+
+        let payload = TabDragPayload(sourceWindowID: windowIdentifier, tabID: tabs[fromIndex].id)
+        let pasteboardItem = NSPasteboardItem()
+        payload.set(on: pasteboardItem)
+
+        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+        draggingItem.setDraggingFrame(convert(dragView.bounds, from: dragView), contents: draggingImage)
+
+        dragSourceIndex = fromIndex
+        dragInsertionIndex = nil
+        isDropAccepted = false
+        ensureDragIndicator()
+        dragIndicatorLayer?.isHidden = true
+
+        let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
+        session.animatesToStartingPositionsOnCancelOrFail = false
+        session.draggingFormation = .none
+    }
+
+    private func dragImage(for view: NSView) -> NSImage? {
+        guard view.bounds.width > 0, view.bounds.height > 0,
+              let representation = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+            return nil
+        }
+        view.cacheDisplay(in: view.bounds, to: representation)
+        let image = NSImage(size: view.bounds.size)
+        image.addRepresentation(representation)
+        return image
+    }
+
+    private func ensureDragIndicator() {
+        guard dragIndicatorLayer == nil else { return }
+        let indicator = CALayer()
+        indicator.backgroundColor = Theme.accent.withAlphaComponent(0.5).cgColor
+        indicator.cornerRadius = 1
+        wantsLayer = true
+        layer?.addSublayer(indicator)
+        dragIndicatorLayer = indicator
+    }
+
+    private func clearDragState() {
+        dragSourceIndex = nil
+        dragInsertionIndex = nil
+        isDropAccepted = false
+        dragIndicatorLayer?.removeFromSuperlayer()
+        dragIndicatorLayer = nil
+    }
+
+    private func insertionIndex(for location: NSPoint) -> Int {
+        guard !tabs.isEmpty else { return 0 }
+
+        if tabs.count <= 1 {
+            return location.x <= singleTabLabel.frame.midX ? 0 : 1
+        }
+
+        for (index, pill) in tabViews.enumerated() {
+            if location.x < pill.frame.midX {
+                return index
             }
         }
 
-        if let target = targetIdx, target != sourceIdx {
-            dragTargetIndex = target
-            let pill = tabViews[target]
-            let indicatorX = target < sourceIdx ? pill.frame.minX - 1 : pill.frame.maxX + 1
-            dragIndicatorLayer?.frame = NSRect(x: indicatorX, y: pill.frame.minY + 4, width: 2, height: pill.frame.height - 8)
-            dragIndicatorLayer?.isHidden = false
-        } else {
-            dragTargetIndex = nil
-            dragIndicatorLayer?.isHidden = true
-        }
+        return tabs.count
     }
 
-    private func endDrag() {
-        guard let sourceIdx = dragSourceIndex else { return }
-        dragIndicatorLayer?.removeFromSuperlayer()
-        dragIndicatorLayer = nil
-
-        let targetIdx = dragTargetIndex ?? sourceIdx
-        dragSourceIndex = nil
-        dragTargetIndex = nil
-        if targetIdx != sourceIdx {
-            onReorderTab?(sourceIdx, targetIdx)
+    private func updateDragIndicatorFrame() {
+        guard let indicator = dragIndicatorLayer,
+              let dragInsertionIndex else {
+            dragIndicatorLayer?.isHidden = true
+            return
         }
+
+        let tabHeight: CGFloat = 30
+        let y = (bounds.height - tabHeight) / 2 + 4
+        let height = tabHeight - 8
+
+        let x: CGFloat
+        if tabs.isEmpty {
+            x = 0
+        } else if tabs.count <= 1 {
+            x = dragInsertionIndex == 0 ? singleTabLabel.frame.minX - 2 : singleTabLabel.frame.maxX + 2
+        } else if dragInsertionIndex <= 0 {
+            x = tabViews.first?.frame.minX ?? 0
+        } else if dragInsertionIndex >= tabViews.count {
+            x = (tabViews.last?.frame.maxX ?? 0) + 6
+        } else {
+            x = tabViews[dragInsertionIndex].frame.minX - 3
+        }
+
+        indicator.frame = NSRect(x: x, y: y, width: 2, height: height)
+        indicator.isHidden = false
+    }
+
+    static func reorderDestinationIndex(sourceIndex: Int, insertionIndex: Int, tabCount: Int) -> Int {
+        guard tabCount > 0 else { return 0 }
+        let clampedInsertion = max(0, min(insertionIndex, tabCount))
+        let adjustedIndex = clampedInsertion > sourceIndex ? clampedInsertion - 1 : clampedInsertion
+        return max(0, min(adjustedIndex, tabCount - 1))
+    }
+
+    // MARK: - NSDraggingSource
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        .move
+    }
+
+    func ignoreModifierKeys(for session: NSDraggingSession) -> Bool {
+        true
+    }
+
+    func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
+        let payload = dragSourceIndex.flatMap { tabs.indices.contains($0) ? tabs[$0].id : nil }
+        let shouldTearOff = operation == [] && !isDropAccepted
+        clearDragState()
+
+        guard shouldTearOff, let tabID = payload else { return }
+        onTearOffTab?(tabID, screenPoint)
+    }
+
+    // MARK: - NSDraggingDestination
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        draggingUpdated(sender)
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard TabDragPayload.read(from: sender.draggingPasteboard) != nil else {
+            dragInsertionIndex = nil
+            updateDragIndicatorFrame()
+            return []
+        }
+
+        ensureDragIndicator()
+        dragInsertionIndex = insertionIndex(for: convert(sender.draggingLocation, from: nil))
+        updateDragIndicatorFrame()
+        return .move
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        dragInsertionIndex = nil
+        updateDragIndicatorFrame()
+    }
+
+    override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        TabDragPayload.read(from: sender.draggingPasteboard) != nil
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let payload = TabDragPayload.read(from: sender.draggingPasteboard) else { return false }
+        let insertionIndex = dragInsertionIndex ?? insertionIndex(for: convert(sender.draggingLocation, from: nil))
+        let sourceIndex = tabs.firstIndex(where: { $0.id == payload.tabID })
+
+        if payload.sourceWindowID == windowIdentifier, let sourceIndex {
+            let destinationIndex = Self.reorderDestinationIndex(
+                sourceIndex: sourceIndex,
+                insertionIndex: insertionIndex,
+                tabCount: tabs.count
+            )
+            if destinationIndex != sourceIndex {
+                onReorderTab?(sourceIndex, destinationIndex)
+            }
+        } else {
+            onReceiveDraggedTab?(payload, insertionIndex)
+        }
+
+        isDropAccepted = true
+        return true
+    }
+
+    override func concludeDragOperation(_ sender: NSDraggingInfo?) {
+        dragInsertionIndex = nil
+        updateDragIndicatorFrame()
     }
 
     @objc private func handleNewTab() {
@@ -211,9 +391,7 @@ fileprivate final class TabPillView: NSView {
     var onSelect: (() -> Void)?
     var onClose: (() -> Void)?
     var onTogglePin: (() -> Void)?
-    var onDragBegan: (() -> Void)?
-    var onDragMoved: ((NSPoint) -> Void)?
-    var onDragEnded: (() -> Void)?
+    var onBeginDrag: ((NSEvent) -> Void)?
     private var isDragging = false
     private var mouseDownLocation: NSPoint?
 
@@ -388,18 +566,14 @@ fileprivate final class TabPillView: NSView {
 
     override func mouseDragged(with event: NSEvent) {
         guard let start = mouseDownLocation else { return }
-        let loc = event.locationInWindow
-        if !isDragging && hypot(loc.x - start.x, loc.y - start.y) > 4 {
+        let location = event.locationInWindow
+        if !isDragging && hypot(location.x - start.x, location.y - start.y) > 4 {
             isDragging = true
-            onDragBegan?()
-        }
-        if isDragging {
-            onDragMoved?(event.locationInWindow)
+            onBeginDrag?(event)
         }
     }
 
     override func mouseUp(with event: NSEvent) {
-        if isDragging { onDragEnded?() }
         isDragging = false
         mouseDownLocation = nil
     }

--- a/Bellith/Views/TabBarView.swift
+++ b/Bellith/Views/TabBarView.swift
@@ -178,7 +178,6 @@ final class TabBarView: NSView, NSDraggingSource {
         }
 
         singleTabMouseDownLocation = event.locationInWindow
-        onSelectTab?(0)
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -194,7 +193,12 @@ final class TabBarView: NSView, NSDraggingSource {
     }
 
     override func mouseUp(with event: NSEvent) {
+        let shouldSelect = singleTabMouseDownLocation != nil
         singleTabMouseDownLocation = nil
+        if shouldSelect {
+            onSelectTab?(0)
+            return
+        }
         super.mouseUp(with: event)
     }
 
@@ -562,7 +566,6 @@ fileprivate final class TabPillView: NSView {
     override func mouseDown(with event: NSEvent) {
         mouseDownLocation = event.locationInWindow
         isDragging = false
-        onSelect?()
     }
 
     override func otherMouseDown(with event: NSEvent) {
@@ -582,8 +585,12 @@ fileprivate final class TabPillView: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
+        let shouldSelect = !isDragging
         isDragging = false
         mouseDownLocation = nil
+        if shouldSelect {
+            onSelect?()
+        }
     }
 
     @objc private func handleClose() {

--- a/Bellith/Views/TabBarView.swift
+++ b/Bellith/Views/TabBarView.swift
@@ -25,6 +25,10 @@ final class TabBarView: NSView, NSDraggingSource {
 
     var windowIdentifier: UUID?
 
+    private var effectiveWindowIdentifier: UUID? {
+        windowIdentifier ?? (window as? TerminalWindow)?.tabDragIdentifier
+    }
+
     private var dragSourceIndex: Int?
     private var dragIndicatorLayer: CALayer?
     private var dragInsertionIndex: Int?
@@ -206,7 +210,7 @@ final class TabBarView: NSView, NSDraggingSource {
     private func beginDragSession(fromIndex: Int, event: NSEvent, dragView: NSView?) {
         guard dragSourceIndex == nil,
               fromIndex >= 0, fromIndex < tabs.count,
-              let windowIdentifier,
+              let windowIdentifier = effectiveWindowIdentifier,
               let dragView,
               let draggingImage = dragImage(for: dragView) else { return }
 
@@ -366,7 +370,7 @@ final class TabBarView: NSView, NSDraggingSource {
         let insertionIndex = dragInsertionIndex ?? insertionIndex(for: convert(sender.draggingLocation, from: nil))
         let sourceIndex = tabs.firstIndex(where: { $0.id == payload.tabID })
 
-        if payload.sourceWindowID == windowIdentifier, let sourceIndex {
+        if payload.sourceWindowID == effectiveWindowIdentifier, let sourceIndex {
             let destinationIndex = Self.reorderDestinationIndex(
                 sourceIndex: sourceIndex,
                 insertionIndex: insertionIndex,

--- a/Bellith/Views/TabBarView.swift
+++ b/Bellith/Views/TabBarView.swift
@@ -397,6 +397,14 @@ fileprivate final class TabPillView: NSView {
 
     override var mouseDownCanMoveWindow: Bool { false }
 
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard bounds.contains(point) else { return nil }
+        if !isPinned, closeButton.frame.contains(point) {
+            return closeButton
+        }
+        return self
+    }
+
     private let iconView = NSImageView()
     private let pinView = NSImageView()
     private let titleLabel = NSTextField(labelWithString: "")

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -96,6 +96,7 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         self.statusBar = StatusBarView(settings: dependencies.settings)
         self.titleBar = TitleBarView(settings: dependencies.settings)
         super.init(frame: .zero)
+        registerForDraggedTypes([TabDragPayload.pasteboardType])
         wantsLayer = true
         applyFrameColor()
         configureChromeLayers()
@@ -2109,6 +2110,46 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
             sidebar.show()
             (window as? TerminalWindow)?.showTrafficLights()
         }
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        draggingUpdated(sender)
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard useSidebar, TabDragPayload.read(from: sender.draggingPasteboard) != nil else {
+            return []
+        }
+
+        let location = convert(sender.draggingLocation, from: nil)
+        if !sidebar.isExpanded && location.x <= 24 {
+            sidebar.show()
+            needsLayout = true
+            layoutSubtreeIfNeeded()
+        }
+
+        guard sidebar.isExpanded, sidebar.frame.contains(location) else { return [] }
+        return sidebar.draggingUpdated(sender)
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        guard useSidebar, sidebar.isExpanded else { return }
+        sidebar.draggingExited(sender)
+    }
+
+    override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard useSidebar else { return false }
+        return sidebar.prepareForDragOperation(sender)
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard useSidebar else { return false }
+        return sidebar.performDragOperation(sender)
+    }
+
+    override func concludeDragOperation(_ sender: NSDraggingInfo?) {
+        guard useSidebar else { return }
+        sidebar.concludeDragOperation(sender)
     }
 
     // MARK: - Command Palette

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -114,6 +114,12 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         }
         sidebar.onReorderTab = { [weak self] from, to in self?.reorderTab(from: from, to: to) }
         sidebar.onTabContextMenu = { [weak self] index, point in self?.showTabContextMenu(index: index, at: point) }
+        sidebar.onReceiveDraggedTab = { [weak self] payload, insertionIndex in
+            self?.receiveDraggedTab(payload, insertionIndex: insertionIndex)
+        }
+        sidebar.onTearOffTab = { [weak self] tabID, screenPoint in
+            self?.tearOffTab(tabID, dropScreenPoint: screenPoint)
+        }
         sidebar.onSelectTool = { [weak self] pluginID in self?.openOrSwitchToTool(pluginID) }
 
         // Tab bar
@@ -1846,6 +1852,7 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         tabBar.windowIdentifier = tabDragWindowID
+        sidebar.windowIdentifier = tabDragWindowID
         lastKnownStatusBarVisible = shouldShowStatusBar
         statusBar.alphaValue = lastKnownStatusBarVisible ? 1 : 0
         updateRuntimeStatusObservers()

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -81,7 +81,11 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
     private let sidebarGlowLayer = CAGradientLayer()
     private let sidebarBridgeLayer = CAGradientLayer()
 
-    init(terminalApp: TerminalApp, dependencies: BellithDependencies = .live) {
+    init(
+        terminalApp: TerminalApp,
+        createInitialTab: Bool = true,
+        dependencies: BellithDependencies = .live
+    ) {
         self.dependencies = dependencies
         self.terminalApp = terminalApp
         self.sidebar = SidebarView(
@@ -119,6 +123,12 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         tabBar.onNewTab = { [weak self] in self?.createTab() }
         tabBar.onReorderTab = { [weak self] from, to in self?.reorderTab(from: from, to: to) }
         tabBar.onTogglePin = { [weak self] i in self?.togglePinTab(i) }
+        tabBar.onReceiveDraggedTab = { [weak self] payload, insertionIndex in
+            self?.receiveDraggedTab(payload, insertionIndex: insertionIndex)
+        }
+        tabBar.onTearOffTab = { [weak self] tabID, screenPoint in
+            self?.tearOffTab(tabID, dropScreenPoint: screenPoint)
+        }
 
         // Status bar (optional, shown beneath the terminal content)
         statusBar.onVisibilityChanged = { [weak self] visible in
@@ -176,7 +186,9 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
             .store(in: &observationCancellables)
 
         installEventMonitorsIfNeeded()
-        createTab()
+        if createInitialTab {
+            createTab()
+        }
     }
 
     deinit {
@@ -792,12 +804,8 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         guard let plugin = dependencies.smartPanelRegistry.plugin(for: pluginID),
               let panel = makeSmartPanel(pluginID: pluginID) else { return }
 
-        // Provide the shell PID and CWD so panels can scope their data
-        panel.shellPID = findShellPID()
-        panel.workingDirectory = currentTerminalCwd()
-        panel.onRequestNewTab = { [weak self] directory in
-            self?.createTab(initialWorkingDirectory: directory)
-        }
+        // Provide the shell PID and CWD so panels can scope their data.
+        prepareSmartPanel(panel)
 
         let id = UUID()
         tabs.append(TabEntry(
@@ -824,6 +832,105 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
             return
         }
         createSmartTab(pluginID: pluginID)
+    }
+
+    static func clampedDropInsertionIndex(
+        requestedIndex: Int,
+        movingPinned: Bool,
+        pinnedCount: Int,
+        tabCount: Int
+    ) -> Int {
+        let clampedIndex = max(0, min(requestedIndex, tabCount))
+        if movingPinned {
+            return min(clampedIndex, pinnedCount)
+        }
+        return max(clampedIndex, pinnedCount)
+    }
+
+    func detachTab(withID id: UUID) -> TabEntry? {
+        guard let index = tabs.firstIndex(where: { $0.id == id }) else { return nil }
+
+        let entry = tabs.remove(at: index)
+        if case .smart(let panel) = entry.content {
+            panel.stopRefreshing()
+        }
+        entry.rootView.removeFromSuperview()
+        entry.rootView.isHidden = true
+
+        if lastSelectedTerminalTabID == id {
+            lastSelectedTerminalTabID = tabs.first(where: \.isTerminal)?.id
+        }
+
+        if tabs.isEmpty {
+            refreshTabUI()
+            DispatchQueue.main.async { [weak self] in
+                self?.window?.close()
+            }
+            return entry
+        }
+
+        if selectedTabIndex > index {
+            selectedTabIndex -= 1
+        } else if selectedTabIndex >= tabs.count {
+            selectedTabIndex = tabs.count - 1
+        }
+
+        selectTab(selectedTabIndex)
+        refreshTabUI()
+        return entry
+    }
+
+    func insertTransferredTab(_ entry: TabEntry, at requestedIndex: Int?) {
+        var transferredEntry = entry
+        let insertIndex = Self.clampedDropInsertionIndex(
+            requestedIndex: requestedIndex ?? tabs.count,
+            movingPinned: transferredEntry.isPinned,
+            pinnedCount: tabs.filter { $0.isPinned }.count,
+            tabCount: tabs.count
+        )
+
+        if case .smart(let panel) = transferredEntry.content {
+            prepareSmartPanel(panel)
+        }
+        for surface in transferredEntry.surfaces {
+            bindSurfaceCallbacks(for: surface, tabId: transferredEntry.id)
+        }
+
+        transferredEntry.rootView.removeFromSuperview()
+        transferredEntry.rootView.isHidden = true
+        tabs.insert(transferredEntry, at: insertIndex)
+        addSubview(transferredEntry.rootView, positioned: .below, relativeTo: sidebar)
+        selectTab(insertIndex)
+        refreshTabUI()
+    }
+
+    private func receiveDraggedTab(_ payload: TabDragPayload, insertionIndex: Int) {
+        guard let appDelegate = NSApp.delegate as? AppDelegate,
+              let destinationWindowID = tabDragWindowID else { return }
+        _ = appDelegate.moveTab(
+            payload.tabID,
+            fromWindowWithID: payload.sourceWindowID,
+            toWindowWithID: destinationWindowID,
+            insertionIndex: insertionIndex
+        )
+    }
+
+    private func tearOffTab(_ tabID: UUID, dropScreenPoint: NSPoint) {
+        guard let appDelegate = NSApp.delegate as? AppDelegate,
+              let sourceWindowID = tabDragWindowID else { return }
+        _ = appDelegate.tearOffTab(tabID, fromWindowWithID: sourceWindowID, dropScreenPoint: dropScreenPoint)
+    }
+
+    private var tabDragWindowID: UUID? {
+        (window as? TerminalWindow)?.tabDragIdentifier
+    }
+
+    private func prepareSmartPanel(_ panel: SmartPanelView) {
+        panel.shellPID = findShellPID()
+        panel.workingDirectory = currentTerminalCwd()
+        panel.onRequestNewTab = { [weak self] directory in
+            self?.createTab(initialWorkingDirectory: directory)
+        }
     }
 
     /// Toggle the pinned state of a tab. Pinning moves the tab to the left of
@@ -1502,9 +1609,12 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
 
     @objc private func contextMenuMoveToNewWindow(_ sender: NSMenuItem) {
         guard let index = sender.representedObject as? Int,
-              let session = sessionState(forTabAt: index) else { return }
-        NotificationCenter.default.post(name: .bellithCreateNewWindow, object: WindowLaunchRequest(session: session))
-        closeTab(index)
+              index >= 0, index < tabs.count,
+              let currentWindow = window else { return }
+
+        let frame = currentWindow.frame
+        let dropPoint = NSPoint(x: frame.midX, y: frame.maxY - 32)
+        tearOffTab(tabs[index].id, dropScreenPoint: dropPoint)
     }
 
     // MARK: - Reopen Closed Tab
@@ -1735,6 +1845,7 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        tabBar.windowIdentifier = tabDragWindowID
         lastKnownStatusBarVisible = shouldShowStatusBar
         statusBar.alphaValue = lastKnownStatusBarVisible ? 1 : 0
         updateRuntimeStatusObservers()
@@ -2263,6 +2374,11 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
     private func makeSurface(tabId: UUID, app: TerminalApp, context: TerminalContext) -> TerminalSurfaceView {
         let surface = TerminalSurfaceView(app: app)
         surface.terminalContext = context
+        bindSurfaceCallbacks(for: surface, tabId: tabId)
+        return surface
+    }
+
+    private func bindSurfaceCallbacks(for surface: TerminalSurfaceView, tabId: UUID) {
         surface.onFocus = { [weak self, weak surface] focusedSurface in
             guard let self, let surface, focusedSurface === surface else { return }
             guard let tabIndex = self.tabs.firstIndex(where: { tab in
@@ -2298,7 +2414,6 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
                 self.statusBar.updateSize(cols: cols, rows: rows)
             }
         }
-        return surface
     }
 
     private func terminalSurface(in view: NSView) -> TerminalSurfaceView? {

--- a/Bellith/Views/TerminalWindow.swift
+++ b/Bellith/Views/TerminalWindow.swift
@@ -4,6 +4,8 @@ import QuartzCore
 /// Custom window with Zen-inspired minimal chrome.
 /// Traffic lights auto-hide after a delay and reappear on hover.
 final class TerminalWindow: NSWindow {
+    let tabDragIdentifier = UUID()
+
     enum TrafficLightDisplayMode {
         case automatic
         case forcedVisible

--- a/BellithTests/SessionStateTests.swift
+++ b/BellithTests/SessionStateTests.swift
@@ -174,6 +174,14 @@ final class SessionStateTests: XCTestCase {
         XCTAssertEqual(decoded.frameDescriptor, "{{10, 20}, {900, 600}}")
     }
 
+    func testTabDragPayloadRoundtrip() throws {
+        let payload = TabDragPayload(sourceWindowID: UUID(), tabID: UUID())
+        let data = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(TabDragPayload.self, from: data)
+
+        XCTAssertEqual(decoded, payload)
+    }
+
     func testLegacySplitTreeDecodesIntoFlattenedTerminalSnapshot() throws {
         let json = """
         {

--- a/BellithTests/TerminalContainerViewTests.swift
+++ b/BellithTests/TerminalContainerViewTests.swift
@@ -33,4 +33,36 @@ final class TerminalContainerViewTests: XCTestCase {
             2
         )
     }
+
+    func testClampedDropInsertionIndexKeepsPinnedTabsInPinnedRegion() {
+        XCTAssertEqual(
+            TerminalContainerView.clampedDropInsertionIndex(
+                requestedIndex: 4,
+                movingPinned: true,
+                pinnedCount: 2,
+                tabCount: 5
+            ),
+            2
+        )
+        XCTAssertEqual(
+            TerminalContainerView.clampedDropInsertionIndex(
+                requestedIndex: 0,
+                movingPinned: false,
+                pinnedCount: 2,
+                tabCount: 5
+            ),
+            2
+        )
+    }
+
+    func testReorderDestinationIndexTreatsInsertionIndexAsEdgeDropTarget() {
+        XCTAssertEqual(
+            TabBarView.reorderDestinationIndex(sourceIndex: 1, insertionIndex: 4, tabCount: 4),
+            3
+        )
+        XCTAssertEqual(
+            TabBarView.reorderDestinationIndex(sourceIndex: 3, insertionIndex: 0, tabCount: 4),
+            0
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- add native tab drag sessions so tabs can be reordered, torn off, and dropped into another window's tab bar
- add the same drag-and-drop behavior to the sidebar tab list so cross-window tab moves work in both tab modes
- reveal the sidebar while dragging near the window edge so drops also work when the sidebar is auto-hidden
- move live tab trees between containers so split layouts, cwd, and running sessions stay intact
- reuse the live transfer path for "Move to New Window" and add focused tests for drag payload/index helpers

## Testing
- make build
- xcodebuild -project Bellith.xcodeproj -scheme Bellith -configuration Debug test -only-testing:BellithTests/SessionStateTests -only-testing:BellithTests/TerminalContainerViewTests
- make test *(still fails in existing BellithSettingsTests/TerminalConfigTests with NSMenuItem submenu assertion unrelated to this change)*

Closes #44