### PR TITLE
feat(ui): add error fix suggestions for failed commands

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		3F067DBCA20A52FB30980DA2 /* SSHProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AC775F3A6A91CF3FE4CDAB /* SSHProfileStoreTests.swift */; };
 		3F81E95CDC0FF4142056C98A /* EnvironmentPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0B5E50A6BE76A1D3EDFE6D /* EnvironmentPanel.swift */; };
 		3FE2152821D44C82B14D0338 /* WallpaperTint.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD317F56432F400BA1567BB /* WallpaperTint.swift */; };
+		42B7B40974F3971A3E5472BF /* CommandFailureSuggestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF85C08BA2DF08A6A597C24 /* CommandFailureSuggestionView.swift */; };
 		448B3D29B0C3C5D8F8A35CC4 /* TabDragPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC212B83257FCC23F5592D /* TabDragPayload.swift */; };
 		459FB063C7F788F4E0E549A5 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89FDA87579791818D3A6718 /* TerminalPane.swift */; };
 		462CADCA785D176937B5F445 /* GitRepositoryInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC203E445CE586B521D8FC29 /* GitRepositoryInfoTests.swift */; };
@@ -48,6 +49,7 @@
 		5863C9295DF764ABD02BC958 /* HyperlinkRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC1927EB617093208667D9 /* HyperlinkRouterTests.swift */; };
 		5DD63722AB2EE526EB096050 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E2025F109793353C35658F9 /* GhosttyKit.xcframework */; };
 		6798D6E2D3D556D644A18E41 /* SSHProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879EFDEE63113B30DD38B6EA /* SSHProfileStore.swift */; };
+		696F6BCF502F546CDEA8F4DB /* CommandFailureSuggestionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5114C1EDE3291AA9D3DB9054 /* CommandFailureSuggestionServiceTests.swift */; };
 		6D65D2902B34E20D77196A44 /* TerminalSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41878447E775AEA363F6EF96 /* TerminalSurfaceView.swift */; };
 		74262591A8DDBF6D4AF2E324 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31E78EB4EBC7FC49C2F22FC /* main.swift */; };
 		765D4B7FDA9B6F3ACD937BEF /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0C524BC98C2F0D18E7B327 /* NetworkMonitor.swift */; };
@@ -95,6 +97,7 @@
 		E450123DFE8F0EBAD8050A69 /* BackdropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27A4F297624101EA6EA1124 /* BackdropView.swift */; };
 		E90F976F4D03F92405690751 /* GitHubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419904C2F6EF539F340C4054 /* GitHubService.swift */; };
 		EC22286AF20F181A9F1AB072 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAA686EB03918C02A471CF0 /* WorkspaceStore.swift */; };
+		EEE40CFFB40FE5F95866734E /* CommandFailureSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1906A16E61449504AD30A3D2 /* CommandFailureSuggestionService.swift */; };
 		F0688F637632B59A01825393 /* TerminalContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72367912169712669D03FD67 /* TerminalContainerView.swift */; };
 		F26474311EB82215B71E0CE0 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC69484808B270DA784451B1 /* SearchBarView.swift */; };
 		F565B2256404B0E12F1759C5 /* AIToolSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7761C9EFFC090C4726758B71 /* AIToolSessionDetector.swift */; };
@@ -122,6 +125,7 @@
 
 /* Begin PBXFileReference section */
 		01AD6AF9F8A70A7E83B56C8C /* QuickTerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickTerminalPane.swift; sourceTree = "<group>"; };
+		0AF85C08BA2DF08A6A597C24 /* CommandFailureSuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandFailureSuggestionView.swift; sourceTree = "<group>"; };
 		0B8A3CDE542974BFD639F6F0 /* CommandRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandRegistry.swift; sourceTree = "<group>"; };
 		0E054D89080718E9732C73F2 /* TerminalConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalConfig.swift; sourceTree = "<group>"; };
 		0E385EC194464E8BF67BE47B /* SplitPaneViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitPaneViewTests.swift; sourceTree = "<group>"; };
@@ -129,6 +133,7 @@
 		1055D889FA5B87C7B010166B /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		17F1A89752C176F1F7719413 /* ShortcutDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutDefinitions.swift; sourceTree = "<group>"; };
 		185BCA9A77D1E03020788D4D /* PreferencesComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesComponents.swift; sourceTree = "<group>"; };
+		1906A16E61449504AD30A3D2 /* CommandFailureSuggestionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandFailureSuggestionService.swift; sourceTree = "<group>"; };
 		1AAA686EB03918C02A471CF0 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		1B08540536C434953689D04D /* SessionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStateTests.swift; sourceTree = "<group>"; };
 		1DDFFEF2B5A4E5BE5E1A7669 /* LocalSessionLaunchBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSessionLaunchBuilderTests.swift; sourceTree = "<group>"; };
@@ -149,6 +154,7 @@
 		469D41729D62F6520EB09E3B /* SmartPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPanelView.swift; sourceTree = "<group>"; };
 		4AAC0EE06A46735764D38F77 /* ToolActivityPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityPanel.swift; sourceTree = "<group>"; };
 		4FD22E965C6F1A921DC3AFFA /* BellithSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellithSettingsTests.swift; sourceTree = "<group>"; };
+		5114C1EDE3291AA9D3DB9054 /* CommandFailureSuggestionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandFailureSuggestionServiceTests.swift; sourceTree = "<group>"; };
 		52E9612F02A1A65DFA8CA240 /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
 		595A49A926D6775A52202AAD /* ITermColorsImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ITermColorsImporter.swift; sourceTree = "<group>"; };
 		5B639E55908BD9DDCD969BFE /* WorkspaceDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDefinition.swift; sourceTree = "<group>"; };
@@ -274,6 +280,7 @@
 			children = (
 				850CD5C03E9934E94F040341 /* AIToolSessionDetectorTests.swift */,
 				4FD22E965C6F1A921DC3AFFA /* BellithSettingsTests.swift */,
+				5114C1EDE3291AA9D3DB9054 /* CommandFailureSuggestionServiceTests.swift */,
 				F9994A85D37354E2BFF60705 /* CommandPaletteViewTests.swift */,
 				AC203E445CE586B521D8FC29 /* GitRepositoryInfoTests.swift */,
 				7CDC1927EB617093208667D9 /* HyperlinkRouterTests.swift */,
@@ -309,6 +316,7 @@
 			children = (
 				C27A4F297624101EA6EA1124 /* BackdropView.swift */,
 				8AF3103FA440F936419F4846 /* BlurView.swift */,
+				0AF85C08BA2DF08A6A597C24 /* CommandFailureSuggestionView.swift */,
 				52E9612F02A1A65DFA8CA240 /* CommandPaletteView.swift */,
 				7B6A4E8E8C5D7B65BB385570 /* ContextBadgeView.swift */,
 				9C964FC62608F8FA41EE01B5 /* QuickTerminalController.swift */,
@@ -406,6 +414,7 @@
 			isa = PBXGroup;
 			children = (
 				7761C9EFFC090C4726758B71 /* AIToolSessionDetector.swift */,
+				1906A16E61449504AD30A3D2 /* CommandFailureSuggestionService.swift */,
 				419904C2F6EF539F340C4054 /* GitHubService.swift */,
 				595A49A926D6775A52202AAD /* ITermColorsImporter.swift */,
 				70C30B5C38334EF708DC86AC /* LocalSessionLaunchBuilder.swift */,
@@ -604,6 +613,7 @@
 			files = (
 				0AF8CB135FF10863D353566B /* AIToolSessionDetectorTests.swift in Sources */,
 				84920B35B7A5167C2AAE9985 /* BellithSettingsTests.swift in Sources */,
+				696F6BCF502F546CDEA8F4DB /* CommandFailureSuggestionServiceTests.swift in Sources */,
 				D976C2EC92ED3D33ECCB9882 /* CommandPaletteViewTests.swift in Sources */,
 				462CADCA785D176937B5F445 /* GitRepositoryInfoTests.swift in Sources */,
 				5863C9295DF764ABD02BC958 /* HyperlinkRouterTests.swift in Sources */,
@@ -637,6 +647,8 @@
 				CCA0508AE25C077D19B7319C /* BellithFont.swift in Sources */,
 				CE826D24B9117475F5BFB14B /* BellithSettings.swift in Sources */,
 				3A8626193F1471C659C10A4A /* BlurView.swift in Sources */,
+				EEE40CFFB40FE5F95866734E /* CommandFailureSuggestionService.swift in Sources */,
+				42B7B40974F3971A3E5472BF /* CommandFailureSuggestionView.swift in Sources */,
 				114F10461A0D9F305FF71202 /* CommandPaletteView.swift in Sources */,
 				A0CFB54241CAA6006E58472C /* CommandRegistry.swift in Sources */,
 				18245BFE622B231108C45FFC /* ContextBadgeView.swift in Sources */,

--- a/Bellith/App/AppDelegate.swift
+++ b/Bellith/App/AppDelegate.swift
@@ -1102,6 +1102,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             if shouldNotifyForCompletedCommand(on: surfaceView, durationSeconds: durationSec) {
                 notifyCompletedCommand(on: surfaceView, durationSeconds: durationSec, exitCode: info.exit_code)
             }
+            if let surfaceView, let container = container(for: surfaceView) {
+                container.handleCompletedCommand(on: surfaceView, exitCode: info.exit_code)
+            }
             return true
 
         case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:

--- a/Bellith/Models/BellithSettings.swift
+++ b/Bellith/Models/BellithSettings.swift
@@ -79,7 +79,8 @@ final class BellithSettings {
             "inlineImagesEnabled",
             "shellIntegrationEnabled", "shellIntegrationCursor", "shellIntegrationTitle",
             "shellIntegrationPath", "shellIntegrationSSHEnv", "shellIntegrationSSHTerminfo",
-            "commandCompletionNotificationsEnabled", "sidebarPinned", "sidebarAutoHide",
+            "commandCompletionNotificationsEnabled", "errorFixSuggestionsEnabled",
+            "sidebarPinned", "sidebarAutoHide",
             "sidebarShowTools", "visorHideOnFocusLoss", "trafficLightAutoHide",
             "legacyPaneSupport",
             "showStatusBar", "showStatusBarContext", "showStatusBarPath",
@@ -311,6 +312,16 @@ final class BellithSettings {
             return true
         }
         set { defaults.set(newValue, forKey: "commandCompletionNotificationsEnabled"); notify() }
+    }
+
+    var errorFixSuggestionsEnabled: Bool {
+        get {
+            if defaults.object(forKey: "errorFixSuggestionsEnabled") != nil {
+                return defaults.bool(forKey: "errorFixSuggestionsEnabled")
+            }
+            return true
+        }
+        set { defaults.set(newValue, forKey: "errorFixSuggestionsEnabled"); notify() }
     }
 
     var commandCompletionNotificationThreshold: Int {
@@ -959,6 +970,7 @@ final class BellithSettings {
             "bellMode": bellMode,
             "commandCompletionNotificationThreshold": commandCompletionNotificationThreshold,
             "commandCompletionNotificationsEnabled": commandCompletionNotificationsEnabled,
+            "errorFixSuggestionsEnabled": errorFixSuggestionsEnabled,
             "confirmClose": confirmClose,
             "cursorBlink": cursorBlink,
             "cursorStyle": cursorStyle,

--- a/Bellith/Services/CommandFailureSuggestionService.swift
+++ b/Bellith/Services/CommandFailureSuggestionService.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+struct CommandFailureSuggestion: Equatable {
+    let title: String
+    let explanation: String
+    let fixCommand: String
+    let matchedLine: String
+}
+
+enum CommandFailureSuggestionService {
+    private static let installFormulaOverrides: [String: String] = [
+        "code": "visual-studio-code",
+        "fd": "fd",
+        "gsed": "gnu-sed",
+        "npm": "node",
+        "python": "python",
+        "python3": "python",
+        "rg": "ripgrep",
+    ]
+
+    private static let errorKeywords = [
+        "command not found",
+        "permission denied",
+        "no such file or directory",
+        "not a git repository",
+        "missing script",
+        "no module named",
+        "cannot find module",
+        "is not a git command",
+        "fatal:",
+        "error:",
+        "error ",
+    ]
+
+    static func suggestion(
+        for transcript: String,
+        exitCode: Int16,
+        foregroundProcessName: String? = nil
+    ) -> CommandFailureSuggestion? {
+        guard exitCode > 0 else { return nil }
+
+        let recentLines = normalizedLines(from: transcript)
+        guard let matchedLine = likelyErrorLine(in: recentLines) else { return nil }
+
+        if let missingCommand = commandNotFound(in: matchedLine) {
+            return CommandFailureSuggestion(
+                title: "Missing command",
+                explanation: "\(quoted(missingCommand)) is not available on your PATH, so the shell could not launch it.",
+                fixCommand: "brew install \(installFormula(for: missingCommand))",
+                matchedLine: matchedLine
+            )
+        }
+
+        if matchedLine.localizedCaseInsensitiveContains("permission denied") {
+            let path = permissionDeniedPath(in: matchedLine)
+            return CommandFailureSuggestion(
+                title: "Permission denied",
+                explanation: path.map {
+                    "\(quoted($0)) is present, but the shell does not have permission to execute it."
+                } ?? "The shell found the target, but it is not executable with the current permissions.",
+                fixCommand: path.map { "chmod +x \(shellQuoted($0))" } ?? "ls -l",
+                matchedLine: matchedLine
+            )
+        }
+
+        if matchedLine.localizedCaseInsensitiveContains("no such file or directory") {
+            let path = missingPath(in: matchedLine)
+            return CommandFailureSuggestion(
+                title: "Missing path",
+                explanation: path.map {
+                    "The command referenced \(quoted($0)), but that path does not exist from the current working directory."
+                } ?? "The command referenced a file or directory that could not be found.",
+                fixCommand: path.map { "ls -la \(shellQuoted($0))" } ?? "pwd && ls -la",
+                matchedLine: matchedLine
+            )
+        }
+
+        if matchedLine.localizedCaseInsensitiveContains("not a git repository") {
+            return CommandFailureSuggestion(
+                title: "Not inside a Git repository",
+                explanation: "Git could not locate a repository from the current working directory.",
+                fixCommand: "git rev-parse --show-toplevel",
+                matchedLine: matchedLine
+            )
+        }
+
+        if gitUnknownSubcommand(in: matchedLine) != nil {
+            return CommandFailureSuggestion(
+                title: "Unknown Git subcommand",
+                explanation: "Git recognized the main command, but not the subcommand that was requested.",
+                fixCommand: "git help -a",
+                matchedLine: matchedLine
+            )
+        }
+
+        if let script = missingScript(in: matchedLine) {
+            return CommandFailureSuggestion(
+                title: "Missing package script",
+                explanation: "The project does not define the \(quoted(script)) script in package.json.",
+                fixCommand: "npm run",
+                matchedLine: matchedLine
+            )
+        }
+
+        if let module = missingPythonModule(in: matchedLine) {
+            return CommandFailureSuggestion(
+                title: "Python module missing",
+                explanation: "Python could not import the module \(quoted(module)).",
+                fixCommand: "python3 -m pip install \(shellQuoted(module))",
+                matchedLine: matchedLine
+            )
+        }
+
+        if let module = missingNodeModule(in: matchedLine) {
+            return CommandFailureSuggestion(
+                title: "Node package missing",
+                explanation: "Node could not resolve the package \(quoted(module)) from the current project.",
+                fixCommand: "npm install \(shellQuoted(module))",
+                matchedLine: matchedLine
+            )
+        }
+
+        guard let helpCommand = fallbackHelpCommand(from: matchedLine, foregroundProcessName: foregroundProcessName) else {
+            return nil
+        }
+
+        return CommandFailureSuggestion(
+            title: "Command exited with status \(exitCode)",
+            explanation: "Bellith spotted this recent error: \(quoted(matchedLine)). The suggested fix opens the command help so you can verify syntax and flags.",
+            fixCommand: helpCommand,
+            matchedLine: matchedLine
+        )
+    }
+
+    private static func normalizedLines(from transcript: String, limit: Int = 64) -> [String] {
+        transcript
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .suffix(limit)
+            .map { $0 }
+    }
+
+    private static func likelyErrorLine(in lines: [String]) -> String? {
+        for line in lines.reversed() where errorKeywords.contains(where: { line.localizedCaseInsensitiveContains($0) }) {
+            return line
+        }
+
+        return lines.reversed().first(where: { !looksLikePrompt($0) })
+    }
+
+    private static func looksLikePrompt(_ line: String) -> Bool {
+        guard let firstCharacter = line.first else { return false }
+        return ["$", "%", "#", "❯"].contains(firstCharacter)
+    }
+
+    private static func commandNotFound(in line: String) -> String? {
+        if let command = firstMatch(in: line, pattern: #"command not found:\s*([^\s]+)"#) {
+            return sanitizedToken(command)
+        }
+        if let command = firstMatch(in: line, pattern: #"^([^:\s]+):\s*command not found"#) {
+            return sanitizedToken(command)
+        }
+        return nil
+    }
+
+    private static func permissionDeniedPath(in line: String) -> String? {
+        if let path = firstMatch(in: line, pattern: #"permission denied:\s*(.+)$"#) {
+            return sanitizedPath(path)
+        }
+        if let path = firstMatch(in: line, pattern: #"^.*?:\s*(.+?):\s*permission denied$"#, options: [.caseInsensitive]) {
+            return sanitizedPath(path)
+        }
+        return nil
+    }
+
+    private static func missingPath(in line: String) -> String? {
+        if let quotedPath = firstMatch(in: line, pattern: #"'([^']+)'"#) {
+            return sanitizedPath(quotedPath)
+        }
+        if let path = firstMatch(in: line, pattern: #":\s*(.+?):\s*No such file or directory$"#, options: [.caseInsensitive]) {
+            return sanitizedPath(path)
+        }
+        if let path = firstMatch(in: line, pattern: #"No such file or directory:\s*(.+)$"#, options: [.caseInsensitive]) {
+            return sanitizedPath(path)
+        }
+        return nil
+    }
+
+    private static func gitUnknownSubcommand(in line: String) -> String? {
+        firstMatch(in: line, pattern: #"git:\s*'([^']+)'\s*is not a git command"#, options: [.caseInsensitive])
+    }
+
+    private static func missingScript(in line: String) -> String? {
+        firstMatch(in: line, pattern: #"Missing script:\s*[\"']([^\"']+)[\"']"#, options: [.caseInsensitive])
+    }
+
+    private static func missingPythonModule(in line: String) -> String? {
+        firstMatch(in: line, pattern: #"No module named ['\"]([^'\"]+)['\"]"#, options: [.caseInsensitive])
+    }
+
+    private static func missingNodeModule(in line: String) -> String? {
+        firstMatch(in: line, pattern: #"Cannot find module ['\"]([^'\"]+)['\"]"#, options: [.caseInsensitive])
+    }
+
+    private static func fallbackHelpCommand(from line: String, foregroundProcessName: String?) -> String? {
+        let command = inferredCommand(from: line) ?? sanitizedToken(foregroundProcessName)
+        guard let command, !command.isEmpty else { return nil }
+        return "\(command) --help"
+    }
+
+    private static func inferredCommand(from line: String) -> String? {
+        if let missingCommand = commandNotFound(in: line) {
+            return missingCommand
+        }
+
+        let separators = CharacterSet(charactersIn: ": ")
+        let prefix = line.components(separatedBy: separators).first
+        return sanitizedToken(prefix)
+    }
+
+    private static func installFormula(for command: String) -> String {
+        installFormulaOverrides[command] ?? command
+    }
+
+    private static func quoted(_ text: String) -> String {
+        "“\(text)”"
+    }
+
+    private static func shellQuoted(_ text: String) -> String {
+        let escaped = text.replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'"
+    }
+
+    private static func sanitizedToken(_ token: String?) -> String? {
+        guard let token else { return nil }
+        let trimmed = token.trimmingCharacters(in: CharacterSet(charactersIn: " \t\n\r'\"`()[]{}<>.,;"))
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func sanitizedPath(_ path: String?) -> String? {
+        guard let path else { return nil }
+        let trimmed = path.trimmingCharacters(in: CharacterSet(charactersIn: " \t\n\r'\""))
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func firstMatch(
+        in text: String,
+        pattern: String,
+        options: NSRegularExpression.Options = []
+    ) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+            return nil
+        }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range), match.numberOfRanges > 1,
+              let captureRange = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+
+        return String(text[captureRange])
+    }
+}

--- a/Bellith/Views/CommandFailureSuggestionView.swift
+++ b/Bellith/Views/CommandFailureSuggestionView.swift
@@ -1,0 +1,176 @@
+import AppKit
+
+final class CommandFailureSuggestionView: NSView {
+    private enum Metrics {
+        static let width: CGFloat = 360
+        static let minHeight: CGFloat = 176
+        static let padding: CGFloat = 14
+        static let buttonHeight: CGFloat = 28
+        static let commandBlockHeight: CGFloat = 44
+    }
+
+    private let blurView = BlurView(material: .hudWindow, radius: 16)
+    private let iconView = NSImageView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let explanationLabel = NSTextField(wrappingLabelWithString: "")
+    private let commandCaptionLabel = NSTextField(labelWithString: "SUGGESTED FIX")
+    private let commandPlate = NSView()
+    private let commandLabel = NSTextField(labelWithString: "")
+    private let insertButton = NSButton()
+    private let dismissButton = NSButton()
+
+    var onInsertFix: (() -> Void)?
+    var onDismiss: (() -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.shadowOpacity = 1
+        layer?.shadowRadius = 22
+        layer?.shadowOffset = CGSize(width: 0, height: -8)
+
+        addSubview(blurView)
+
+        iconView.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: nil)
+        iconView.imageScaling = .scaleProportionallyDown
+        blurView.addSubview(iconView)
+
+        titleLabel.font = BellithFont.ui(13, weight: .semibold)
+        blurView.addSubview(titleLabel)
+
+        explanationLabel.font = BellithFont.ui(12, weight: .regular)
+        explanationLabel.maximumNumberOfLines = 0
+        explanationLabel.lineBreakMode = .byWordWrapping
+        blurView.addSubview(explanationLabel)
+
+        commandCaptionLabel.font = BellithFont.mono(10, weight: .semibold)
+        blurView.addSubview(commandCaptionLabel)
+
+        commandPlate.wantsLayer = true
+        commandPlate.layer?.cornerRadius = 10
+        commandPlate.layer?.borderWidth = 0.5
+        blurView.addSubview(commandPlate)
+
+        commandLabel.font = BellithFont.mono(12, weight: .regular)
+        commandLabel.lineBreakMode = .byTruncatingMiddle
+        commandPlate.addSubview(commandLabel)
+
+        configureButton(insertButton, title: "Insert Fix", action: #selector(handleInsertFix))
+        configureButton(dismissButton, title: "Dismiss", action: #selector(handleDismiss))
+        blurView.addSubview(insertButton)
+        blurView.addSubview(dismissButton)
+
+        refreshTheme()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    func update(with suggestion: CommandFailureSuggestion) {
+        titleLabel.stringValue = suggestion.title
+        explanationLabel.stringValue = suggestion.explanation
+        commandLabel.stringValue = suggestion.fixCommand
+        toolTip = suggestion.matchedLine
+        needsLayout = true
+    }
+
+    func preferredHeight(for width: CGFloat = Metrics.width) -> CGFloat {
+        let innerWidth = width - Metrics.padding * 2
+        let explanationWidth = innerWidth
+        let explanationHeight = textHeight(
+            for: explanationLabel.attributedStringValue,
+            width: explanationWidth
+        )
+
+        let totalHeight = Metrics.padding
+            + 18
+            + 8
+            + explanationHeight
+            + 10
+            + 14
+            + 6
+            + Metrics.commandBlockHeight
+            + 12
+            + Metrics.buttonHeight
+            + Metrics.padding
+        return max(Metrics.minHeight, ceil(totalHeight))
+    }
+
+    override func layout() {
+        super.layout()
+        blurView.frame = bounds
+
+        let pad = Metrics.padding
+        let innerWidth = bounds.width - pad * 2
+
+        iconView.frame = NSRect(x: pad, y: bounds.height - pad - 18, width: 16, height: 16)
+        titleLabel.frame = NSRect(x: pad + 24, y: bounds.height - pad - 19, width: innerWidth - 24, height: 18)
+
+        let explanationHeight = textHeight(
+            for: explanationLabel.attributedStringValue,
+            width: innerWidth
+        )
+        let explanationY = titleLabel.frame.minY - 8 - explanationHeight
+        explanationLabel.frame = NSRect(x: pad, y: explanationY, width: innerWidth, height: explanationHeight)
+
+        commandCaptionLabel.frame = NSRect(x: pad, y: explanationLabel.frame.minY - 22, width: innerWidth, height: 14)
+        commandPlate.frame = NSRect(x: pad, y: commandCaptionLabel.frame.minY - 6 - Metrics.commandBlockHeight, width: innerWidth, height: Metrics.commandBlockHeight)
+        commandLabel.frame = NSRect(x: 12, y: 12, width: commandPlate.bounds.width - 24, height: 18)
+
+        let buttonWidth = (innerWidth - 8) / 2
+        dismissButton.frame = NSRect(x: pad, y: pad, width: buttonWidth, height: Metrics.buttonHeight)
+        insertButton.frame = NSRect(x: dismissButton.frame.maxX + 8, y: pad, width: buttonWidth, height: Metrics.buttonHeight)
+    }
+
+    func refreshTheme() {
+        layer?.shadowColor = Theme.warning.withAlphaComponent(0.14).cgColor
+        iconView.contentTintColor = Theme.warning
+        titleLabel.textColor = Theme.textPrimary
+        explanationLabel.textColor = Theme.textSecondary
+        commandCaptionLabel.textColor = Theme.textMuted
+        commandPlate.layer?.backgroundColor = Theme.chromePanel.withAlphaComponent(0.92).cgColor
+        commandPlate.layer?.borderColor = Theme.warning.withAlphaComponent(0.18).cgColor
+        commandLabel.textColor = Theme.warning
+        refreshButtonTheme(insertButton, fillColor: Theme.warning.withAlphaComponent(0.22), textColor: Theme.warning)
+        refreshButtonTheme(dismissButton, fillColor: Theme.overlay, textColor: Theme.textSecondary)
+    }
+
+    private func configureButton(_ button: NSButton, title: String, action: Selector) {
+        button.title = title
+        button.target = self
+        button.action = action
+        button.isBordered = false
+        button.bezelStyle = .rounded
+        button.font = BellithFont.ui(12, weight: .medium)
+        button.focusRingType = .none
+        button.wantsLayer = true
+        button.layer?.cornerRadius = 8
+        button.layer?.masksToBounds = true
+    }
+
+    private func refreshButtonTheme(_ button: NSButton, fillColor: NSColor, textColor: NSColor) {
+        button.layer?.backgroundColor = fillColor.cgColor
+        button.contentTintColor = textColor
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: textColor,
+            .font: BellithFont.ui(12, weight: .medium),
+        ]
+        button.attributedTitle = NSAttributedString(string: button.title, attributes: attributes)
+    }
+
+    private func textHeight(for attributedString: NSAttributedString, width: CGFloat) -> CGFloat {
+        let rect = attributedString.boundingRect(
+            with: NSSize(width: width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        )
+        return max(18, ceil(rect.height))
+    }
+
+    @objc private func handleInsertFix() {
+        onInsertFix?()
+    }
+
+    @objc private func handleDismiss() {
+        onDismiss?()
+    }
+}

--- a/Bellith/Views/Preferences/TerminalPane.swift
+++ b/Bellith/Views/Preferences/TerminalPane.swift
@@ -72,6 +72,8 @@ final class TerminalPane: NSView {
     private var shellIntegrationSSHTerminfoToggle: PrefToggle!
     private let commandNotificationsLabel = CardRowLabel("Completion Notifications")
     private var commandNotificationsToggle: PrefToggle!
+    private let errorFixSuggestionsLabel = CardRowLabel("Error Fix Suggestions")
+    private var errorFixSuggestionsToggle: PrefToggle!
     private let commandNotificationThresholdLabel = CardRowLabel("Notify After")
     private var commandNotificationThresholdField: MiniNumberField!
     private let commandNotificationThresholdUnit = SmallLabel("SECONDS")
@@ -250,6 +252,9 @@ final class TerminalPane: NSView {
         commandNotificationsToggle = PrefToggle(isOn: settings.commandCompletionNotificationsEnabled) { [weak self] value in
             self?.settings.commandCompletionNotificationsEnabled = value
         }
+        errorFixSuggestionsToggle = PrefToggle(isOn: settings.errorFixSuggestionsEnabled) { [weak self] value in
+            self?.settings.errorFixSuggestionsEnabled = value
+        }
         commandNotificationThresholdField = MiniNumberField(
             value: settings.commandCompletionNotificationThreshold,
             range: 1...3_600
@@ -272,6 +277,8 @@ final class TerminalPane: NSView {
             shellIntegrationSSHTerminfoToggle,
             commandNotificationsLabel,
             commandNotificationsToggle,
+            errorFixSuggestionsLabel,
+            errorFixSuggestionsToggle,
             commandNotificationThresholdLabel,
             commandNotificationThresholdField,
             commandNotificationThresholdUnit,
@@ -353,6 +360,7 @@ final class TerminalPane: NSView {
         shellIntegrationSSHEnvToggle.setOn(settings.shellIntegrationSSHEnv)
         shellIntegrationSSHTerminfoToggle.setOn(settings.shellIntegrationSSHTerminfo)
         commandNotificationsToggle.setOn(settings.commandCompletionNotificationsEnabled)
+        errorFixSuggestionsToggle.setOn(settings.errorFixSuggestionsEnabled)
         commandNotificationThresholdField.setValue(settings.commandCompletionNotificationThreshold)
         inlineImagesToggle.setOn(settings.inlineImagesEnabled)
         optionKeyPopup.selectItem(at: TerminalOptionKeyBehavior.allCases.firstIndex(of: settings.terminalOptionKeyBehavior) ?? 0)
@@ -475,7 +483,7 @@ final class TerminalPane: NSView {
         y += sessionCardHeight + PreferencesLayout.sectionGap
 
         let shellLabelW = PreferencesLayout.labelWidth(toTrailingToggleIn: cardW)
-        let shellIntegrationCardHeight = shellIntegrationCard.headerHeight + 8 * PreferencesLayout.rowH + 7 * PreferencesLayout.rowGap + PreferencesLayout.cardPad + 14
+        let shellIntegrationCardHeight = shellIntegrationCard.headerHeight + 9 * PreferencesLayout.rowH + 8 * PreferencesLayout.rowGap + PreferencesLayout.cardPad + 14
         shellIntegrationCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardW, height: shellIntegrationCardHeight)
         let ir0 = shellIntegrationCardHeight - shellIntegrationCard.headerHeight - PreferencesLayout.rowH
         shellIntegrationEnabledLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: ir0, width: shellLabelW, height: PreferencesLayout.rowH)
@@ -499,9 +507,12 @@ final class TerminalPane: NSView {
         commandNotificationsLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: ir6, width: shellLabelW, height: PreferencesLayout.rowH)
         commandNotificationsToggle.frame = PreferencesLayout.trailingToggleFrame(cardWidth: cardW, rowY: ir6)
         let ir7 = ir6 - PreferencesLayout.rowH - PreferencesLayout.rowGap
-        commandNotificationThresholdLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: ir7, width: shellLabelW, height: PreferencesLayout.rowH)
-        commandNotificationThresholdField.frame = NSRect(x: controlX, y: ir7 + 6, width: 96, height: 28)
-        commandNotificationThresholdUnit.frame = NSRect(x: controlX + 106, y: ir7 + 12, width: 64, height: 12)
+        errorFixSuggestionsLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: ir7, width: shellLabelW, height: PreferencesLayout.rowH)
+        errorFixSuggestionsToggle.frame = PreferencesLayout.trailingToggleFrame(cardWidth: cardW, rowY: ir7)
+        let ir8 = ir7 - PreferencesLayout.rowH - PreferencesLayout.rowGap
+        commandNotificationThresholdLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: ir8, width: shellLabelW, height: PreferencesLayout.rowH)
+        commandNotificationThresholdField.frame = NSRect(x: controlX, y: ir8 + 6, width: 96, height: 28)
+        commandNotificationThresholdUnit.frame = NSRect(x: controlX + 106, y: ir8 + 12, width: 64, height: 12)
         shellIntegrationNote.frame = NSRect(x: PreferencesLayout.cardPad, y: PreferencesLayout.cardPad - 2, width: innerW, height: 14)
         y += shellIntegrationCardHeight + PreferencesLayout.sectionGap
 

--- a/Bellith/Views/TerminalContainerView.swift
+++ b/Bellith/Views/TerminalContainerView.swift
@@ -68,6 +68,9 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
     )] = []
     private static let maxRecentlyClosed = 10
     private var zoomBadge: NSView?
+    private var commandFailureSuggestionView: CommandFailureSuggestionView?
+    private var commandFailureSuggestion: CommandFailureSuggestion?
+    private weak var commandFailureSuggestionSurface: TerminalSurfaceView?
     private var lastKnownStatusBarVisible = false
     private var observationCancellables = Set<AnyCancellable>()
     private var windowObservationCancellables = Set<AnyCancellable>()
@@ -182,6 +185,11 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
                 }
                 self.needsLayout = true
                 self.reloadConfig()
+                if !self.dependencies.settings.errorFixSuggestionsEnabled || !self.dependencies.settings.shellIntegrationEnabled {
+                    self.clearCommandFailureSuggestion()
+                } else {
+                    self.updateCommandFailureSuggestionVisibility()
+                }
             }
             .store(in: &observationCancellables)
 
@@ -994,6 +1002,9 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         if case .smart(let panel) = entry.content {
             panel.stopRefreshing()
         }
+        if entry.surfaces.contains(where: { $0 === commandFailureSuggestionSurface }) {
+            clearCommandFailureSuggestion()
+        }
         for s in entry.surfaces { s.onClose = nil }
 
         // Fade out + subtle scale-down when closing a tab
@@ -1149,6 +1160,7 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         }
 
         updateChromeFrames(animated: previousIndex != index)
+        updateCommandFailureSuggestionVisibility()
         refreshTabUI()
     }
 
@@ -1796,6 +1808,9 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
                     guard let currentIdx = self.tabs.firstIndex(where: { $0.id == id }) else { return }
                     parent.removeChild(leaf)
                     self.tabs[currentIdx].removeSurface(surface)
+                    if self.commandFailureSuggestionSurface === surface {
+                        self.clearCommandFailureSuggestion()
+                    }
                     if currentIdx == self.selectedTabIndex {
                         self.window?.makeFirstResponder(self.tabs[currentIdx].focusedSurface)
                         root.animateLayout(duration: Theme.animMedium)
@@ -1959,6 +1974,17 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
                 height: badgeH
             )
         }
+
+        if let suggestionView = commandFailureSuggestionView, suggestionView.superview != nil {
+            let suggestedWidth = min(420, max(300, rect.width * 0.4))
+            let panelHeight = suggestionView.preferredHeight(for: suggestedWidth)
+            suggestionView.frame = NSRect(
+                x: rect.maxX - suggestedWidth - 14,
+                y: rect.minY + 14,
+                width: suggestedWidth,
+                height: panelHeight
+            )
+        }
     }
 
     private func animateContentLayout(statusBarVisible explicitStatusBarVisible: Bool? = nil) {
@@ -2071,6 +2097,7 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         }
         (zoomBadge as? ZoomBadge)?.refreshTheme()
         (broadcastBadge as? BroadcastBadge)?.refreshTheme()
+        commandFailureSuggestionView?.refreshTheme()
         updateChromeFrames(animated: false)
         updateFocusIndicator()
         reloadConfig()
@@ -2273,6 +2300,95 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
         }
     }
 
+    func handleCompletedCommand(on surface: TerminalSurfaceView, exitCode: Int16) {
+        guard dependencies.settings.shellIntegrationEnabled,
+              dependencies.settings.errorFixSuggestionsEnabled else {
+            if commandFailureSuggestionSurface === surface {
+                clearCommandFailureSuggestion()
+            }
+            return
+        }
+
+        guard exitCode > 0 else {
+            if commandFailureSuggestionSurface === surface {
+                clearCommandFailureSuggestion()
+            }
+            return
+        }
+
+        guard isSurfaceVisible(surface),
+              window?.isVisible == true,
+              window?.isKeyWindow == true,
+              let transcript = surface.readScreenText(),
+              let suggestion = CommandFailureSuggestionService.suggestion(
+                  for: transcript,
+                  exitCode: exitCode,
+                  foregroundProcessName: surface.lastForegroundPresentation?.text
+              ) else {
+            if commandFailureSuggestionSurface === surface {
+                clearCommandFailureSuggestion()
+            }
+            return
+        }
+
+        commandFailureSuggestionSurface = surface
+        commandFailureSuggestion = suggestion
+        updateCommandFailureSuggestionVisibility()
+    }
+
+    private func updateCommandFailureSuggestionVisibility() {
+        guard dependencies.settings.shellIntegrationEnabled,
+              dependencies.settings.errorFixSuggestionsEnabled,
+              let suggestion = commandFailureSuggestion,
+              let surface = commandFailureSuggestionSurface,
+              isSurfaceVisible(surface) else {
+            commandFailureSuggestionView?.removeFromSuperview()
+            if commandFailureSuggestionSurface == nil {
+                commandFailureSuggestion = nil
+            }
+            needsLayout = true
+            return
+        }
+
+        let view: CommandFailureSuggestionView
+        if let existingView = commandFailureSuggestionView {
+            view = existingView
+        } else {
+            let newView = CommandFailureSuggestionView()
+            newView.onInsertFix = { [weak self] in
+                self?.insertSuggestedFixCommand()
+            }
+            newView.onDismiss = { [weak self] in
+                self?.clearCommandFailureSuggestion()
+            }
+            commandFailureSuggestionView = newView
+            view = newView
+        }
+
+        view.update(with: suggestion)
+        view.refreshTheme()
+        if view.superview == nil {
+            addSubview(view, positioned: .below, relativeTo: overlayReferenceView)
+        }
+        needsLayout = true
+    }
+
+    private func clearCommandFailureSuggestion() {
+        commandFailureSuggestion = nil
+        commandFailureSuggestionSurface = nil
+        commandFailureSuggestionView?.removeFromSuperview()
+        needsLayout = true
+    }
+
+    private func insertSuggestedFixCommand() {
+        guard let surface = commandFailureSuggestionSurface,
+              isSurfaceVisible(surface),
+              let fixCommand = commandFailureSuggestion?.fixCommand else { return }
+        window?.makeFirstResponder(surface)
+        surface.insertCommandText(fixCommand)
+        clearCommandFailureSuggestion()
+    }
+
     // MARK: - Font Size
 
     func adjustFontSizePublic(delta: Int) { adjustFontSize(delta: delta) }
@@ -2435,6 +2551,7 @@ final class TerminalContainerView: NSView, TerminalOverlayControllerHost, Termin
 
             self.tabs[tabIndex].focusedSurface = surface
             if tabIndex == self.selectedTabIndex {
+                self.updateCommandFailureSuggestionVisibility()
                 self.titleBar.updateContext(surface.displayContext)
                 self.statusBar.updateContext(surface.displayContext)
                 self.updateFocusIndicator()

--- a/Bellith/Views/TerminalSurfaceView.swift
+++ b/Bellith/Views/TerminalSurfaceView.swift
@@ -322,6 +322,10 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
         }
     }
 
+    func insertCommandText(_ text: String) {
+        sendTextToSurface(text)
+    }
+
     private func sendTextToSurface(_ text: String) {
         guard let surface else { return }
         text.withCString { ptr in
@@ -329,7 +333,6 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
         }
         onTextInserted?(text, self)
     }
-
 
     private static func shellInsertText(for urls: [URL]) -> String {
         urls.map { shellQuoted($0.path) }.joined(separator: " ") + " "

--- a/BellithTests/BellithSettingsTests.swift
+++ b/BellithTests/BellithSettingsTests.swift
@@ -101,6 +101,7 @@ final class BellithSettingsTests: XCTestCase {
 
     func testDefaultCommandCompletionNotificationSettings() {
         XCTAssertTrue(settings.commandCompletionNotificationsEnabled)
+        XCTAssertTrue(settings.errorFixSuggestionsEnabled)
         XCTAssertEqual(settings.commandCompletionNotificationThreshold, 10)
     }
 
@@ -305,9 +306,11 @@ final class BellithSettingsTests: XCTestCase {
 
     func testCommandCompletionNotificationRoundtrip() {
         settings.commandCompletionNotificationsEnabled = false
+        settings.errorFixSuggestionsEnabled = false
         settings.commandCompletionNotificationThreshold = 42
 
         XCTAssertFalse(settings.commandCompletionNotificationsEnabled)
+        XCTAssertFalse(settings.errorFixSuggestionsEnabled)
         XCTAssertEqual(settings.commandCompletionNotificationThreshold, 42)
     }
 

--- a/BellithTests/CommandFailureSuggestionServiceTests.swift
+++ b/BellithTests/CommandFailureSuggestionServiceTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Bellith
+
+final class CommandFailureSuggestionServiceTests: XCTestCase {
+    func testReturnsNilForSuccessfulExit() {
+        let suggestion = CommandFailureSuggestionService.suggestion(
+            for: "zsh% echo ok\nok",
+            exitCode: 0,
+            foregroundProcessName: "echo"
+        )
+
+        XCTAssertNil(suggestion)
+    }
+
+    func testSuggestsBrewInstallForMissingCommand() {
+        let suggestion = CommandFailureSuggestionService.suggestion(
+            for: "zsh: command not found: rg",
+            exitCode: 127,
+            foregroundProcessName: "rg"
+        )
+
+        XCTAssertEqual(suggestion?.title, "Missing command")
+        XCTAssertEqual(suggestion?.fixCommand, "brew install ripgrep")
+    }
+
+    func testSuggestsChmodForPermissionDenied() {
+        let suggestion = CommandFailureSuggestionService.suggestion(
+            for: "zsh: permission denied: ./scripts/setup.sh",
+            exitCode: 126,
+            foregroundProcessName: "./scripts/setup.sh"
+        )
+
+        XCTAssertEqual(suggestion?.title, "Permission denied")
+        XCTAssertEqual(suggestion?.fixCommand, "chmod +x './scripts/setup.sh'")
+    }
+
+    func testSuggestsGitTopLevelWhenRepoMissing() {
+        let suggestion = CommandFailureSuggestionService.suggestion(
+            for: "fatal: not a git repository (or any of the parent directories): .git",
+            exitCode: 128,
+            foregroundProcessName: "git"
+        )
+
+        XCTAssertEqual(suggestion?.title, "Not inside a Git repository")
+        XCTAssertEqual(suggestion?.fixCommand, "git rev-parse --show-toplevel")
+    }
+
+    func testSuggestsPipInstallForMissingPythonModule() {
+        let transcript = "Traceback (most recent call last):\nModuleNotFoundError: No module named 'rich'"
+        let suggestion = CommandFailureSuggestionService.suggestion(
+            for: transcript,
+            exitCode: 1,
+            foregroundProcessName: "python3"
+        )
+
+        XCTAssertEqual(suggestion?.title, "Python module missing")
+        XCTAssertEqual(suggestion?.fixCommand, "python3 -m pip install 'rich'")
+    }
+
+    func testFallsBackToCommandHelpForUnknownFailure() {
+        let suggestion = CommandFailureSuggestionService.suggestion(
+            for: "git: unknown option --example",
+            exitCode: 129,
+            foregroundProcessName: "git"
+        )
+
+        XCTAssertEqual(suggestion?.title, "Command exited with status 129")
+        XCTAssertEqual(suggestion?.fixCommand, "git --help")
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight failed-command suggestion engine that turns common terminal errors into explanation + fix commands
- present an unobtrusive insertable suggestion panel for active terminal failures detected from command-finished OSC 133 events
- add a global Terminal preference to disable error fix suggestions and cover the matcher with unit tests

## Testing
- `make generate`
- `make build`
- `make test` *(fails in pre-existing BellithSettingsTests/TerminalConfigTests with NSMenuItem submenu assertions unrelated to this change; new CommandFailureSuggestionServiceTests pass within the run)*

Closes #42