### PR TITLE
feat(ui): add scrollback minimap

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4859630C40EA72D0F6A13448 /* SSHLaunchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A6320778E024E8ABCDF2A6 /* SSHLaunchBuilder.swift */; };
 		4C6D7ECB973811FC8DA4121C /* ProcessMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A46EAB948FDDFB1C12E4B9 /* ProcessMonitor.swift */; };
 		4DDD96881F2A1409729CD580 /* HyperlinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2088BFA03DDDC079DE5DB8C /* HyperlinkRouter.swift */; };
+		4E51EEB1C2092382F475B24B /* ScrollbackMinimapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03168242417C9553954DD3F4 /* ScrollbackMinimapView.swift */; };
 		55B5329D0C164FDCBEE88A5D /* ToolActivityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6157DFCE204C3ADC26FA72 /* ToolActivityMonitor.swift */; };
 		5863C9295DF764ABD02BC958 /* HyperlinkRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC1927EB617093208667D9 /* HyperlinkRouterTests.swift */; };
 		5DD63722AB2EE526EB096050 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E2025F109793353C35658F9 /* GhosttyKit.xcframework */; };
@@ -125,6 +126,7 @@
 
 /* Begin PBXFileReference section */
 		01AD6AF9F8A70A7E83B56C8C /* QuickTerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickTerminalPane.swift; sourceTree = "<group>"; };
+		03168242417C9553954DD3F4 /* ScrollbackMinimapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollbackMinimapView.swift; sourceTree = "<group>"; };
 		0AF85C08BA2DF08A6A597C24 /* CommandFailureSuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandFailureSuggestionView.swift; sourceTree = "<group>"; };
 		0B8A3CDE542974BFD639F6F0 /* CommandRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandRegistry.swift; sourceTree = "<group>"; };
 		0E054D89080718E9732C73F2 /* TerminalConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalConfig.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 				52E9612F02A1A65DFA8CA240 /* CommandPaletteView.swift */,
 				7B6A4E8E8C5D7B65BB385570 /* ContextBadgeView.swift */,
 				9C964FC62608F8FA41EE01B5 /* QuickTerminalController.swift */,
+				03168242417C9553954DD3F4 /* ScrollbackMinimapView.swift */,
 				EC69484808B270DA784451B1 /* SearchBarView.swift */,
 				BB30AA7FAF949D6830C55830 /* ShortcutCheatSheetView.swift */,
 				EA87F2112E9FD1A9C106D8F2 /* SidebarView.swift */,
@@ -679,6 +682,7 @@
 				00EC7090FE625A045A9BEF48 /* SSHProfile.swift in Sources */,
 				6798D6E2D3D556D644A18E41 /* SSHProfileStore.swift in Sources */,
 				2BC36AC2F4C1DD3823B68CA5 /* SSHSessionDetector.swift in Sources */,
+				4E51EEB1C2092382F475B24B /* ScrollbackMinimapView.swift in Sources */,
 				F26474311EB82215B71E0CE0 /* SearchBarView.swift in Sources */,
 				D18360F5978A3344A622645C /* SessionBootstrapCommandBuilder.swift in Sources */,
 				3AA2DA3E813BBA3E1B8CF1B9 /* SessionState.swift in Sources */,

--- a/Bellith/App/AppDelegate.swift
+++ b/Bellith/App/AppDelegate.swift
@@ -1119,8 +1119,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             if shouldNotifyForCompletedCommand(on: surfaceView, durationSeconds: durationSec) {
                 notifyCompletedCommand(on: surfaceView, durationSeconds: durationSec, exitCode: info.exit_code)
             }
-            if let surfaceView, let container = container(for: surfaceView) {
-                container.handleCompletedCommand(on: surfaceView, exitCode: info.exit_code)
+            if let surfaceView {
+                surfaceView.recordCommandMark(exitCode: info.exit_code)
+                if let container = container(for: surfaceView) {
+                    container.handleCompletedCommand(on: surfaceView, exitCode: info.exit_code)
+                }
             }
             return true
 
@@ -1135,6 +1138,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return true
 
         case GHOSTTY_ACTION_SCROLLBAR:
+            let bar = action.action.scrollbar
+            if let surfaceView = surfaceView(for: target) {
+                surfaceView.updateScrollbarState(
+                    total: Int(bar.total),
+                    offset: Int(bar.offset),
+                    len: Int(bar.len)
+                )
+            }
             return true
 
         case GHOSTTY_ACTION_START_SEARCH:
@@ -1149,6 +1160,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
         case GHOSTTY_ACTION_END_SEARCH:
             activeEntry?.container.hideSearch()
+            if let surfaceView = surfaceView(for: target) {
+                surfaceView.clearMinimapSearchSelection()
+            }
             return true
 
         case GHOSTTY_ACTION_SEARCH_TOTAL:
@@ -1159,6 +1173,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         case GHOSTTY_ACTION_SEARCH_SELECTED:
             let selected = Int(action.action.search_selected.selected)
             activeEntry?.container.updateSearchSelected(selected)
+            if let surfaceView = surfaceView(for: target) {
+                surfaceView.updateMinimapSearchSelection()
+            }
             return true
 
         default:

--- a/Bellith/Models/BellithSettings.swift
+++ b/Bellith/Models/BellithSettings.swift
@@ -77,6 +77,7 @@ final class BellithSettings {
         static let boolKeys: Set<String> = [
             "mouseHideWhileTyping", "confirmClose", "restoreSession", "cursorBlink",
             "inlineImagesEnabled",
+            "scrollbackMinimapEnabled",
             "shellIntegrationEnabled", "shellIntegrationCursor", "shellIntegrationTitle",
             "shellIntegrationPath", "shellIntegrationSSHEnv", "shellIntegrationSSHTerminfo",
             "commandCompletionNotificationsEnabled", "errorFixSuggestionsEnabled",
@@ -199,6 +200,16 @@ final class BellithSettings {
     var scrollbackLines: Int {
         get { let v = defaults.integer(forKey: "scrollbackLines"); return v > 0 ? v : 10000 }
         set { defaults.set(newValue, forKey: "scrollbackLines"); notify() }
+    }
+
+    var scrollbackMinimapEnabled: Bool {
+        get {
+            if defaults.object(forKey: "scrollbackMinimapEnabled") != nil {
+                return defaults.bool(forKey: "scrollbackMinimapEnabled")
+            }
+            return false
+        }
+        set { defaults.set(newValue, forKey: "scrollbackMinimapEnabled"); notify() }
     }
 
     var mouseHideWhileTyping: Bool {
@@ -976,6 +987,7 @@ final class BellithSettings {
             "noiseIntensity": roundedForSettingsFile(noiseIntensity),
             "restoreSession": restoreSession,
             "scrollbackLines": scrollbackLines,
+            "scrollbackMinimapEnabled": scrollbackMinimapEnabled,
             "shell": shell,
             "legacyPaneSupport": legacyPaneSupport,
             "localSessionBootstrap": localSessionBootstrap.rawValue,

--- a/Bellith/Views/Preferences/TerminalPane.swift
+++ b/Bellith/Views/Preferences/TerminalPane.swift
@@ -79,10 +79,13 @@ final class TerminalPane: NSView {
     private let commandNotificationThresholdUnit = SmallLabel("SECONDS")
     private let shellIntegrationNote = FooterNote("Prompt marks, command timing, and completion notifications require shell integration.")
 
-    private let graphicsCard = SettingsCard(title: "Graphics", subtitle: "Inline image protocols supported by Ghostty")
+    private let graphicsCard = SettingsCard(title: "Display", subtitle: "Inline images and scrollback navigation aids")
     private let inlineImagesLabel = CardRowLabel("Inline Images")
     private var inlineImagesToggle: PrefToggle!
     private let inlineImagesNote = FooterNote("Enables Kitty graphics and Sixel so tools like icat, chafa, timg, and gnuplot draw directly in the terminal.")
+    private let minimapLabel = CardRowLabel("Scrollback Minimap")
+    private var minimapToggle: PrefToggle!
+    private let minimapNote = FooterNote("Shows a zoomed-out strip along the right edge of each pane for rapid scrollback navigation.")
 
     private let behaviorCard = SettingsCard(title: "Behavior", subtitle: "Session lifecycle, cursor visibility, and terminal modifier keys")
     private let optionKeyLabel = CardRowLabel("Option Key")
@@ -296,8 +299,14 @@ final class TerminalPane: NSView {
         inlineImagesToggle = PrefToggle(isOn: settings.inlineImagesEnabled) { [weak self] value in
             self?.settings.inlineImagesEnabled = value
         }
+        minimapToggle = PrefToggle(isOn: settings.scrollbackMinimapEnabled) { [weak self] value in
+            self?.settings.scrollbackMinimapEnabled = value
+        }
         content.addSubview(graphicsCard)
-        for view: NSView in [inlineImagesLabel, inlineImagesToggle, inlineImagesNote] {
+        for view: NSView in [
+            inlineImagesLabel, inlineImagesToggle, inlineImagesNote,
+            minimapLabel, minimapToggle, minimapNote,
+        ] {
             graphicsCard.addSubview(view)
         }
 
@@ -363,6 +372,7 @@ final class TerminalPane: NSView {
         errorFixSuggestionsToggle.setOn(settings.errorFixSuggestionsEnabled)
         commandNotificationThresholdField.setValue(settings.commandCompletionNotificationThreshold)
         inlineImagesToggle.setOn(settings.inlineImagesEnabled)
+        minimapToggle.setOn(settings.scrollbackMinimapEnabled)
         optionKeyPopup.selectItem(at: TerminalOptionKeyBehavior.allCases.firstIndex(of: settings.terminalOptionKeyBehavior) ?? 0)
         hideMouseToggle.setOn(settings.mouseHideWhileTyping)
         confirmToggle.setOn(settings.confirmClose)
@@ -517,12 +527,16 @@ final class TerminalPane: NSView {
         y += shellIntegrationCardHeight + PreferencesLayout.sectionGap
 
         let graphicsLabelW = PreferencesLayout.labelWidth(toTrailingToggleIn: cardW)
-        let graphicsCardHeight = graphicsCard.headerHeight + PreferencesLayout.rowH + 14 + PreferencesLayout.rowGap + PreferencesLayout.cardPad
+        let graphicsCardHeight = graphicsCard.headerHeight + 2 * PreferencesLayout.rowH + 2 * 14 + 2 * PreferencesLayout.rowGap + PreferencesLayout.cardPad
         graphicsCard.frame = NSRect(x: PreferencesLayout.hPad, y: y, width: cardW, height: graphicsCardHeight)
         let gr0 = graphicsCardHeight - graphicsCard.headerHeight - PreferencesLayout.rowH
         inlineImagesLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: gr0, width: graphicsLabelW, height: PreferencesLayout.rowH)
         inlineImagesToggle.frame = PreferencesLayout.trailingToggleFrame(cardWidth: cardW, rowY: gr0)
         inlineImagesNote.frame = NSRect(x: PreferencesLayout.cardPad, y: gr0 - 16, width: innerW, height: 14)
+        let gr1 = gr0 - PreferencesLayout.rowH - 14 - PreferencesLayout.rowGap
+        minimapLabel.frame = NSRect(x: PreferencesLayout.cardPad, y: gr1, width: graphicsLabelW, height: PreferencesLayout.rowH)
+        minimapToggle.frame = PreferencesLayout.trailingToggleFrame(cardWidth: cardW, rowY: gr1)
+        minimapNote.frame = NSRect(x: PreferencesLayout.cardPad, y: gr1 - 16, width: innerW, height: 14)
         y += graphicsCardHeight + PreferencesLayout.sectionGap
 
         let behaviorCardHeight = behaviorCard.headerHeight + 4 * PreferencesLayout.rowH + 14 + 3 * PreferencesLayout.rowGap + PreferencesLayout.cardPad

--- a/Bellith/Views/ScrollbackMinimapView.swift
+++ b/Bellith/Views/ScrollbackMinimapView.swift
@@ -1,0 +1,214 @@
+import AppKit
+
+/// Thin vertical strip along the right edge of a terminal surface that shows
+/// a zoomed-out representation of the scrollback. Users can click to jump or
+/// drag to scrub the viewport to any position.
+final class ScrollbackMinimapView: NSView {
+    enum MarkKind {
+        case prompt
+        case error
+        case searchHit
+    }
+
+    struct Mark {
+        let row: Int
+        let kind: MarkKind
+    }
+
+    static let defaultWidth: CGFloat = 14
+
+    var onScrollToRow: ((Int) -> Void)?
+
+    private var total: Int = 0
+    private var offset: Int = 0
+    private var len: Int = 0
+    private var marks: [Mark] = []
+    private var searchHitRow: Int?
+    private var hovering = false
+    private var themeObserver: NSObjectProtocol?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+        setAccessibilityRole(.slider)
+        setAccessibilityLabel("Scrollback Minimap")
+        themeObserver = NotificationCenter.default.addObserver(
+            forName: ThemeManager.didChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.needsDisplay = true
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    deinit {
+        if let themeObserver {
+            NotificationCenter.default.removeObserver(themeObserver)
+        }
+    }
+
+    override var isFlipped: Bool { false }
+
+    override func updateTrackingAreas() {
+        trackingAreas.forEach { removeTrackingArea($0) }
+        addTrackingArea(NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        hovering = true
+        needsDisplay = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        hovering = false
+        needsDisplay = true
+    }
+
+    // MARK: - State
+
+    func updateScrollbar(total: Int, offset: Int, len: Int) {
+        let clampedTotal = max(0, total)
+        let clampedLen = max(0, min(len, clampedTotal))
+        let clampedOffset = max(0, min(offset, max(0, clampedTotal - clampedLen)))
+        guard total != self.total || offset != self.offset || len != self.len else { return }
+        self.total = clampedTotal
+        self.offset = clampedOffset
+        self.len = clampedLen
+        needsDisplay = true
+    }
+
+    func appendMark(row: Int, kind: MarkKind) {
+        marks.append(Mark(row: row, kind: kind))
+        if marks.count > 2000 {
+            marks.removeFirst(marks.count - 2000)
+        }
+        needsDisplay = true
+    }
+
+    func clearMarks() {
+        guard !marks.isEmpty || searchHitRow != nil else { return }
+        marks.removeAll()
+        searchHitRow = nil
+        needsDisplay = true
+    }
+
+    func setSearchHit(row: Int?) {
+        guard searchHitRow != row else { return }
+        searchHitRow = row
+        needsDisplay = true
+    }
+
+    var hasScrollback: Bool { total > len && total > 0 }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        let r = bounds
+
+        // Translucent track
+        let trackAlpha: CGFloat = hovering ? 0.22 : 0.12
+        ctx.setFillColor(Theme.border.withAlphaComponent(trackAlpha).cgColor)
+        let trackInset: CGFloat = 3
+        let trackRect = r.insetBy(dx: trackInset, dy: 2)
+        ctx.addPath(CGPath(roundedRect: trackRect, cornerWidth: 2, cornerHeight: 2, transform: nil))
+        ctx.fillPath()
+
+        guard total > 0, len > 0 else { return }
+
+        let travelHeight = r.height
+        let rowPerPixel = CGFloat(total) / travelHeight
+
+        // Marks first, so the thumb paints over them.
+        for mark in marks {
+            drawMark(mark, in: ctx, travelHeight: travelHeight)
+        }
+        if let row = searchHitRow {
+            drawSearchHit(row: row, in: ctx, travelHeight: travelHeight)
+        }
+
+        // Viewport thumb
+        let thumbHeight = max(24, CGFloat(len) / max(1, rowPerPixel))
+        let usableHeight = travelHeight - thumbHeight
+        let progress = total > len ? CGFloat(offset) / CGFloat(total - len) : 0
+        let thumbY = usableHeight - (progress * usableHeight)
+        let thumbRect = NSRect(
+            x: trackInset,
+            y: max(0, thumbY),
+            width: r.width - 2 * trackInset,
+            height: thumbHeight
+        )
+        let thumbColor = hovering
+            ? Theme.accent.withAlphaComponent(0.9)
+            : Theme.accent.withAlphaComponent(0.55)
+        ctx.setFillColor(thumbColor.cgColor)
+        ctx.addPath(CGPath(roundedRect: thumbRect, cornerWidth: 3, cornerHeight: 3, transform: nil))
+        ctx.fillPath()
+    }
+
+    private func drawMark(_ mark: Mark, in ctx: CGContext, travelHeight: CGFloat) {
+        guard total > 0 else { return }
+        let progress = CGFloat(mark.row) / CGFloat(total)
+        // flipped: row 0 (oldest) is at top of strip
+        let y = travelHeight - progress * travelHeight
+        let (color, height): (NSColor, CGFloat) = {
+            switch mark.kind {
+            case .prompt: return (Theme.textMuted.withAlphaComponent(0.55), 1.2)
+            case .error: return (Theme.destructive.withAlphaComponent(0.85), 2.0)
+            case .searchHit: return (Theme.accent.withAlphaComponent(0.85), 1.5)
+            }
+        }()
+        ctx.setFillColor(color.cgColor)
+        ctx.fill(NSRect(x: 0, y: y - height / 2, width: bounds.width, height: height))
+    }
+
+    private func drawSearchHit(row: Int, in ctx: CGContext, travelHeight: CGFloat) {
+        guard total > 0 else { return }
+        let progress = CGFloat(row) / CGFloat(total)
+        let y = travelHeight - progress * travelHeight
+        let height: CGFloat = 3
+        ctx.setFillColor(Theme.accent.cgColor)
+        ctx.fill(NSRect(x: 0, y: y - height / 2, width: bounds.width, height: height))
+    }
+
+    // MARK: - Mouse
+
+    override func mouseDown(with event: NSEvent) {
+        guard total > len else { return }
+        let point = convert(event.locationInWindow, from: nil)
+        emitScroll(toPoint: point)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard total > len else { return }
+        let point = convert(event.locationInWindow, from: nil)
+        emitScroll(toPoint: point)
+    }
+
+    private func emitScroll(toPoint point: NSPoint) {
+        let travelHeight = bounds.height
+        guard travelHeight > 0 else { return }
+        // Flip so top of strip = oldest row = row 0
+        let clampedY = max(0, min(travelHeight, point.y))
+        let fromTop = travelHeight - clampedY
+        let progress = fromTop / travelHeight
+        let maxOffset = max(0, total - len)
+        var target = Int((progress * CGFloat(maxOffset)).rounded())
+        target = max(0, min(target, maxOffset))
+        onScrollToRow?(target)
+    }
+
+    // MARK: - Cursor
+
+    override func resetCursorRects() {
+        discardCursorRects()
+        addCursorRect(bounds, cursor: .pointingHand)
+    }
+}

--- a/Bellith/Views/TerminalSurfaceView.swift
+++ b/Bellith/Views/TerminalSurfaceView.swift
@@ -16,6 +16,11 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
     private var focused = false
     private let dropIndicatorLayer = CALayer()
     private let temporaryDropDirectoryURL = TerminalSurfaceView.temporaryDropDirectoryURL()
+    private var minimapView: ScrollbackMinimapView?
+    private var lastScrollbarTotal: Int = 0
+    private var lastScrollbarOffset: Int = 0
+    private var lastScrollbarLen: Int = 0
+    private var settingsObserver: NSObjectProtocol?
 
     /// Called when the shell process exits or the surface requests close.
     var onClose: ((Bool) -> Void)?
@@ -69,6 +74,13 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyUp]) { [weak self] event in
             self?.localKeyUp(event) ?? event
         }
+
+        applyMinimapPreference()
+        settingsObserver = NotificationCenter.default.addObserver(
+            forName: BellithSettings.didChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.applyMinimapPreference()
+        }
     }
 
     @available(*, unavailable)
@@ -77,6 +89,7 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
     deinit {
         Self.cleanupTemporaryDropDirectory(at: temporaryDropDirectoryURL)
         if let eventMonitor { NSEvent.removeMonitor(eventMonitor) }
+        if let settingsObserver { NotificationCenter.default.removeObserver(settingsObserver) }
         if let surface { ghostty_surface_free(surface) }
     }
 
@@ -160,6 +173,87 @@ final class TerminalSurfaceView: NSView, NSTextInputClient {
         CATransaction.setDisableActions(true)
         dropIndicatorLayer.frame = bounds.insetBy(dx: 6, dy: 6)
         CATransaction.commit()
+        layoutMinimap()
+    }
+
+    // MARK: - Scrollback Minimap
+
+    private func applyMinimapPreference() {
+        let enabled = BellithSettings.shared.scrollbackMinimapEnabled
+        if enabled {
+            if minimapView == nil {
+                let minimap = ScrollbackMinimapView(frame: .zero)
+                minimap.onScrollToRow = { [weak self] row in
+                    self?.scrollToRow(row)
+                }
+                addSubview(minimap)
+                minimapView = minimap
+                minimap.updateScrollbar(
+                    total: lastScrollbarTotal,
+                    offset: lastScrollbarOffset,
+                    len: lastScrollbarLen
+                )
+            }
+        } else {
+            minimapView?.removeFromSuperview()
+            minimapView = nil
+        }
+        layoutMinimap()
+    }
+
+    private func layoutMinimap() {
+        guard let minimap = minimapView else { return }
+        let width = ScrollbackMinimapView.defaultWidth
+        let topInset: CGFloat = 2
+        let bottomInset: CGFloat = 2
+        minimap.frame = NSRect(
+            x: bounds.width - width,
+            y: bottomInset,
+            width: width,
+            height: max(0, bounds.height - topInset - bottomInset)
+        )
+    }
+
+    func updateScrollbarState(total: Int, offset: Int, len: Int) {
+        lastScrollbarTotal = total
+        lastScrollbarOffset = offset
+        lastScrollbarLen = len
+        minimapView?.updateScrollbar(total: total, offset: offset, len: len)
+    }
+
+    func recordCommandMark(exitCode: Int16) {
+        guard let minimap = minimapView else { return }
+        // Use the bottom-of-viewport row as the approximate prompt/command line.
+        let markRow = lastScrollbarOffset + max(0, lastScrollbarLen - 1)
+        minimap.appendMark(row: markRow, kind: exitCode == 0 ? .prompt : .error)
+    }
+
+    func resetMinimapMarks() {
+        minimapView?.clearMarks()
+    }
+
+    func updateMinimapSearchSelection() {
+        guard let minimap = minimapView else { return }
+        // Search automatically scrolls the selected hit into view, so the
+        // current viewport centre is a good proxy for the hit row.
+        if lastScrollbarLen > 0 && lastScrollbarTotal > 0 {
+            let row = lastScrollbarOffset + lastScrollbarLen / 2
+            minimap.setSearchHit(row: row)
+        } else {
+            minimap.setSearchHit(row: nil)
+        }
+    }
+
+    func clearMinimapSearchSelection() {
+        minimapView?.setSearchHit(row: nil)
+    }
+
+    private func scrollToRow(_ row: Int) {
+        guard let surface else { return }
+        let action = "scroll_to_row:\(row)"
+        action.withCString { ptr in
+            _ = ghostty_surface_binding_action(surface, ptr, UInt(action.utf8.count))
+        }
     }
 
     override func setFrameSize(_ newSize: NSSize) {

--- a/BellithTests/BellithSettingsTests.swift
+++ b/BellithTests/BellithSettingsTests.swift
@@ -66,6 +66,18 @@ final class BellithSettingsTests: XCTestCase {
         XCTAssertEqual(settings.scrollbackLines, 10000)
     }
 
+    func testDefaultScrollbackMinimapDisabled() {
+        XCTAssertFalse(settings.scrollbackMinimapEnabled)
+    }
+
+    func testScrollbackMinimapTogglePersists() {
+        settings.scrollbackMinimapEnabled = true
+        XCTAssertTrue(settings.scrollbackMinimapEnabled)
+
+        let reloaded = BellithSettings(defaults: defaults, settingsFileURL: settingsFileURL)
+        XCTAssertTrue(reloaded.scrollbackMinimapEnabled)
+    }
+
     func testDefaultMouseHideWhileTyping() {
         XCTAssertTrue(settings.mouseHideWhileTyping)
     }


### PR DESCRIPTION
Closes #47

## Summary
- New optional **Scrollback Minimap** strip on the right edge of every terminal pane, rendering viewport position from libghostty's `GHOSTTY_ACTION_SCROLLBAR` (`total` / `offset` / `len`).
- **Click to jump** and **drag to scrub** — both send `scroll_to_row:<N>` through `ghostty_surface_binding_action`, mapping the click/drag Y to an absolute scrollback row.
- **Highlights**:
  - Prompt marks: every `COMMAND_FINISHED` with `exit_code == 0` places a muted tick.
  - Error marks: non-zero exit codes place a brighter destructive-colored tick.
  - Search hit: the current active selection (from `GHOSTTY_ACTION_SEARCH_SELECTED`) draws a bright accent bar; `GHOSTTY_ACTION_END_SEARCH` clears it.
- **Preference toggle** at _Preferences → Terminal → Display → Scrollback Minimap_ (off by default). The Graphics card was renamed to **Display** since it now covers more than inline-image protocols.

## Implementation notes
- `Bellith/Views/ScrollbackMinimapView.swift` — thin `NSView` that owns the viewport thumb, mark ticks, and mouse handling. Uses `Theme` colors so it tracks light/dark theme swaps.
- `TerminalSurfaceView` owns one minimap per surface, lazily creates/removes it based on the new setting, and keeps last-seen scrollbar state so toggling shows the current viewport immediately.
- `AppDelegate.handleAction`:
  - `GHOSTTY_ACTION_SCROLLBAR`: was previously a no-op — now routes to the matching surface's `updateScrollbarState`.
  - `GHOSTTY_ACTION_COMMAND_FINISHED`: records a mark (prompt vs error) on the surface before the existing container handler runs.
  - `GHOSTTY_ACTION_SEARCH_SELECTED` / `GHOSTTY_ACTION_END_SEARCH`: keep the minimap search indicator in sync.
- Prompt/error mark rows are approximated from the current scrollbar offset + viewport height. This requires shell integration (for `COMMAND_FINISHED`) to be enabled.

## Known limitations / follow-ups
- Search hits are rendered only for the _active_ match. libghostty doesn't expose per-hit positions in `SEARCH_TOTAL`, so "all hits" highlighting would need an upstream API addition.
- The minimap overlays the rightmost column of text with a translucent track (same z-order model as `SearchBarView`). Reserving gutter space would require surface-level padding support from libghostty.

## Test plan
- [x] `make build` (Debug) passes.
- [x] Added `BellithSettingsTests` coverage for the default-off state and persistence of the toggle.
- [ ] Manual UI verification: toggle on in Preferences; confirm right-edge strip appears, thumb tracks scrolling, click jumps viewport, drag scrubs smoothly.
- [ ] Manual UI verification: run shell-integration commands; confirm muted ticks appear for successes and bright ticks for failures.
- [ ] Manual UI verification: `Cmd-F` search; confirm an accent bar marks the selected hit and clears when search closes.
- [ ] `make test` — currently unable to run in this environment due to a pre-existing `@testable import Bellith` module resolution issue (also fails on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)