### PR TITLE
docs: add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Rodrigo Espinosa Curbelo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -117,4 +117,6 @@ Bellith/
 
 ## License
 
-This project uses [GhosttyKit](https://ghostty.org) for terminal rendering. See Ghostty's license for details on framework usage.
+Bellith is released under the [MIT License](./LICENSE).
+
+Bellith bundles [GhosttyKit](https://ghostty.org) for terminal rendering. GhosttyKit is distributed under Ghostty's own (MIT-compatible) license — see the upstream project for details.


### PR DESCRIPTION
## Summary
- Add top-level `LICENSE` with MIT terms (compatible with GhosttyKit's MIT license, unblocks distribution / a Homebrew cask under #74).
- Rewrite the README "License" section to point at the new file and call out GhosttyKit separately.

Closes #71.

## Test plan
- [x] `LICENSE` present at repo root
- [x] README "License" section links to `./LICENSE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)