### PR TITLE
build: derive version strings from git tag + commit count

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 				AD25C25F1F20F07E225479E5 /* Resources */,
 				EA08AA80D81307CF5B4BAF8F /* Frameworks */,
 				2750E7815A8C61345A367EF5 /* Embed bellith CLI */,
+				7F716890074A1CAF1368C798 /* Stamp version from git */,
 				204543A95711977EF5010CA0 /* SwiftLint */,
 			);
 			buildRules = (
@@ -606,6 +607,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "CLI_SRC=\"$BUILT_PRODUCTS_DIR/bellith\"\nCLI_DST=\"$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME/Contents/Resources/bellith\"\nif [ -f \"$CLI_SRC\" ]; then\n  mkdir -p \"$(dirname \"$CLI_DST\")\"\n  cp -f \"$CLI_SRC\" \"$CLI_DST\"\n  chmod +x \"$CLI_DST\"\nfi\n";
+		};
+		7F716890074A1CAF1368C798 /* Stamp version from git */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Stamp version from git";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/scripts/stamp-version.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Bellith/Info.plist
+++ b/Bellith/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.0.0-dev</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![macOS 14+](https://img.shields.io/badge/macOS-14.0%2B-blue)
 ![Swift 5.10](https://img.shields.io/badge/Swift-5.10-orange)
-![Version 0.1.0](https://img.shields.io/badge/version-0.1.0-green)
+![Latest release](https://img.shields.io/github/v/tag/RodrigoEspinosa/bellith?label=release&color=green)
 
 ## Features
 

--- a/project.yml
+++ b/project.yml
@@ -54,6 +54,10 @@ targets:
         name: Embed bellith CLI
         basedOnDependencyAnalysis: false
       - script: |
+          "$SRCROOT/scripts/stamp-version.sh"
+        name: Stamp version from git
+        basedOnDependencyAnalysis: false
+      - script: |
           if command -v swiftlint >/dev/null 2>&1; then
             swiftlint lint --config "$SRCROOT/.swiftlint.yml" 2>/dev/null || true
           fi

--- a/scripts/stamp-version.sh
+++ b/scripts/stamp-version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Stamp CFBundleShortVersionString / CFBundleVersion on the built app bundle.
+#
+# Resolution order:
+#   1. $BELLITH_MARKETING_VERSION / $BELLITH_BUILD_NUMBER (explicit, used by CI)
+#   2. git tag (stripped of a leading "v") / git rev-list --count
+#   3. "0.0.0-dev" / "1" fallback
+set -euo pipefail
+
+repo_root="${SRCROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+version="${BELLITH_MARKETING_VERSION:-}"
+build="${BELLITH_BUILD_NUMBER:-}"
+
+if [ -z "$version" ]; then
+  if tag=$(git -C "$repo_root" describe --tags --abbrev=0 2>/dev/null); then
+    version="${tag#v}"
+  fi
+fi
+: "${version:=0.0.0-dev}"
+
+if [ -z "$build" ]; then
+  if count=$(git -C "$repo_root" rev-list --count HEAD 2>/dev/null); then
+    build="$count"
+  fi
+fi
+: "${build:=1}"
+
+target_build_dir="${TARGET_BUILD_DIR:-}"
+infoplist_path="${INFOPLIST_PATH:-}"
+if [ -z "$target_build_dir" ] || [ -z "$infoplist_path" ]; then
+  echo "stamp-version: TARGET_BUILD_DIR or INFOPLIST_PATH unset; skipping" >&2
+  exit 0
+fi
+
+plist="$target_build_dir/$infoplist_path"
+if [ ! -f "$plist" ]; then
+  echo "stamp-version: $plist not found; skipping" >&2
+  exit 0
+fi
+
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $version" "$plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build" "$plist"
+echo "stamp-version: $version ($build) -> $plist"


### PR DESCRIPTION
## Summary
- Replace hardcoded \`CFBundleShortVersionString = 0.1.0\` / \`CFBundleVersion = 1\` with a sentinel in \`Info.plist\`, then stamp the real values onto the built \`.app\` bundle in a new post-build phase (\`scripts/stamp-version.sh\`).
- Resolution order: \`\$BELLITH_MARKETING_VERSION\`/\`\$BELLITH_BUILD_NUMBER\` env vars (used by CI) → latest git tag (\`v0.2.0\` → \`0.2.0\`) + \`git rev-list --count HEAD\` → \`0.0.0-dev\` / \`1\` fallback.
- About pane, Preferences \"About\" screen, and \`BellithBranding\` helper all read from \`Bundle.main.infoDictionary\`, so they pick up the stamped values at runtime with no code changes.
- Swap the static \`Version 0.1.0\` README badge for a live GitHub tag badge that updates automatically once releases exist.

Unblocks meaningful Sparkle update ordering (#50) and crash-report attribution once distribution lands.

Closes #73.

## Test plan
- [x] \`make generate && make build\` succeeds locally
- [x] \`PlistBuddy -c \"Print :CFBundleShortVersionString\"\` on the built app reports the tag (\`0.1.0\`), not \`0.0.0-dev\`
- [x] \`PlistBuddy -c \"Print :CFBundleVersion\"\` reports the commit count (\`79\` on this branch)
- [ ] CI override verified once the release workflow from #50/#74 is in place (pass \`BELLITH_MARKETING_VERSION=0.2.0 BELLITH_BUILD_NUMBER=100 xcodebuild …\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)