### PR TITLE
build: privacy manifest + hardened runtime

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		6D65D2902B34E20D77196A44 /* TerminalSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41878447E775AEA363F6EF96 /* TerminalSurfaceView.swift */; };
 		74262591A8DDBF6D4AF2E324 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31E78EB4EBC7FC49C2F22FC /* main.swift */; };
 		765D4B7FDA9B6F3ACD937BEF /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0C524BC98C2F0D18E7B327 /* NetworkMonitor.swift */; };
+		784226302741DD7113718E7E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D7B76343FF4883C7B0533EAB /* PrivacyInfo.xcprivacy */; };
 		7B41F3CE5DB2BA28D89D339C /* SmartPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469D41729D62F6520EB09E3B /* SmartPanelView.swift */; };
 		7F18C8E24F67D3ECEEF7332C /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAEAFE7F888E5EFF104DCE /* FeatureFlags.swift */; };
 		7F77B0D9CD2EBB86D801E76B /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21183D4A7A9CA0A0013ED67A /* Theme.swift */; };
@@ -213,6 +214,7 @@
 		D391C65B83BEE0FDBEAE9ACC /* KeyBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindings.swift; sourceTree = "<group>"; };
 		D589B7C0CC3E08F11671DDFA /* SettingsNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigation.swift; sourceTree = "<group>"; };
 		D65ED0D10E5739FCA342E50A /* PreferencesPaneRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesPaneRegistry.swift; sourceTree = "<group>"; };
+		D7B76343FF4883C7B0533EAB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D7F6C0E62F0D6DFD08E3A8E5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DB0C524BC98C2F0D18E7B327 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		DDFFF00A8FCA7C5D765650BD /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 			isa = PBXGroup;
 			children = (
 				C6D8A2F2C2B69B1DF8B695CA /* Assets.xcassets */,
+				D7B76343FF4883C7B0533EAB /* PrivacyInfo.xcprivacy */,
 				77DA8562D603F051F9AFAEE5 /* App */,
 				2DFA76A5A35BFC692A95E5A4 /* Bridge */,
 				C8083A37D985A7B13AA5B057 /* Models */,
@@ -563,6 +566,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8504ED57A71B5C4492164E11 /* Assets.xcassets in Resources */,
+				784226302741DD7113718E7E /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -748,6 +752,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -766,6 +771,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_DEBUG_DYLIB = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
@@ -795,6 +801,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -813,6 +820,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_DEBUG_DYLIB = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",

--- a/Bellith/Bellith.entitlements
+++ b/Bellith/Bellith.entitlements
@@ -2,7 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- Terminal emulator: must fork/exec arbitrary child processes; cannot run in App Sandbox. -->
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
+
+	<!-- Hardened Runtime: keep the attack surface minimal while supporting a terminal's legitimate needs. -->
+
+	<!-- Child shells (node, python, some language runtimes) JIT-compile code. -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+
+	<!-- JIT-compiling children write executable pages that are not code-signed. -->
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+
+	<!-- GhosttyKit is a third-party XCFramework with its own signing identity; we need to load it. -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+
+	<!-- User shells rely on DYLD_* env vars (e.g. DYLD_LIBRARY_PATH) for custom toolchains. -->
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
 </dict>
 </plist>

--- a/Bellith/PrivacyInfo.xcprivacy
+++ b/Bellith/PrivacyInfo.xcprivacy
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- CA92.1: read/write our own app preferences (themes, session restore, shortcuts) -->
+				<string>CA92.1</string>
+				<!-- 1C8F.1: read system-wide user preferences (locale, global NSUserDefaults domain) -->
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -1,0 +1,52 @@
+# Security posture
+
+This document records Bellith's stance on the App Sandbox, Hardened Runtime, and the privacy manifest, so future maintainers can re-evaluate each decision instead of re-deriving it.
+
+## App Sandbox: disabled
+
+`com.apple.security.app-sandbox = false` in `Bellith/Bellith.entitlements`.
+
+A terminal emulator's core job is to `fork`/`exec` arbitrary user processes (login shell, `ssh`, `vim`, `node`, whatever the user types). The App Sandbox forbids spawning processes outside a narrow allowlist and denies the `PTY` master/child setup that GhosttyKit relies on. There is no sandbox profile that preserves this behaviour — every shipping macOS terminal (Terminal.app, iTerm2, Warp, Alacritty, Ghostty itself) runs outside the sandbox for the same reason.
+
+Distribution is still safe because the app is signed with Developer ID, notarized, runs under Hardened Runtime, and does not ship with the Mac App Store entitlement — Gatekeeper still verifies signature + notarization ticket on first launch.
+
+## Hardened Runtime: enabled
+
+`ENABLE_HARDENED_RUNTIME = YES` in `project.yml` for both the `Bellith` app target and the `bellith-cli` helper. Notarization requires this, and it protects against library-injection / code-tampering attacks regardless of the sandbox status.
+
+The minimal entitlements needed to keep the app functional are declared in `Bellith/Bellith.entitlements`:
+
+| Entitlement | Why Bellith needs it |
+|---|---|
+| `com.apple.security.cs.allow-jit` | Child shells (`node`, `python`, language runtimes with JIT) write executable pages. Hardened runtime blocks this by default. |
+| `com.apple.security.cs.allow-unsigned-executable-memory` | JIT children write executable pages that are not code-signed. |
+| `com.apple.security.cs.disable-library-validation` | GhosttyKit is a third-party `XCFramework` with its own signing identity; without this, `dlopen` of the framework is denied under Hardened Runtime. |
+| `com.apple.security.cs.allow-dyld-environment-variables` | User shells and build tools rely on `DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`, etc. for custom toolchains. |
+
+These are the same entitlements iTerm2 ships with, minus the App-Group one (we do not use app groups).
+
+We intentionally do **not** grant:
+
+- `com.apple.security.cs.debugger` — no need to attach to other processes outside our child chain.
+- `com.apple.security.get-task-allow` — disabled in Release; this keeps `lldb` from attaching to shipped builds.
+
+## Privacy manifest
+
+`Bellith/PrivacyInfo.xcprivacy` is bundled into `Contents/Resources/`. Apple requires one for notarization of any new binary that touches a "required reason" API.
+
+Declared usage:
+
+- `NSPrivacyAccessedAPICategoryUserDefaults` with reasons `CA92.1` (own preferences) and `1C8F.1` (system-global `NSUserDefaults` domain, read for locale).
+
+`NSPrivacyTracking = false`, `NSPrivacyCollectedDataTypes = []`, `NSPrivacyTrackingDomains = []`. Bellith does not collect, transmit, or aggregate user data.
+
+If the app starts calling further required-reason APIs (file timestamps, disk space, system boot time, active keyboard), extend the manifest before the next release.
+
+## Notarization dry-run
+
+```bash
+make build
+codesign -dvvv "$(xcodebuild -project Bellith.xcodeproj -scheme Bellith -showBuildSettings | awk '/BUILT_PRODUCTS_DIR/{print $3}')/Bellith.app"
+```
+
+Expect to see `flags=0x10000(runtime)` and the full entitlement list above. CI's notarization step (see #50) is the authoritative check — run `notarytool submit --wait` on the packaged DMG.

--- a/project.yml
+++ b/project.yml
@@ -20,12 +20,16 @@ targets:
         excludes:
           - "*.entitlements"
           - "Info.plist"
+          - "PrivacyInfo.xcprivacy"
+      - path: Bellith/PrivacyInfo.xcprivacy
+        buildPhase: resources
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.rec.bellith
         INFOPLIST_FILE: Bellith/Info.plist
         CODE_SIGN_ENTITLEMENTS: Bellith/Bellith.entitlements
         CODE_SIGN_STYLE: Automatic
+        ENABLE_HARDENED_RUNTIME: YES
         ENABLE_DEBUG_DYLIB: NO
         SWIFT_OBJC_BRIDGING_HEADER: ""
         OTHER_LDFLAGS:
@@ -70,6 +74,7 @@ targets:
         PRODUCT_NAME: bellith
         SKIP_INSTALL: YES
         CODE_SIGN_STYLE: Automatic
+        ENABLE_HARDENED_RUNTIME: YES
 
   BellithTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary
- Add \`Bellith/PrivacyInfo.xcprivacy\` declaring the single required-reason API the app actually uses (\`NSUserDefaults\`, reasons \`CA92.1\` + \`1C8F.1\`). No tracking, no collected data.
- Keep \`com.apple.security.app-sandbox = false\` (terminals need unrestricted \`fork\`/\`exec\`) and add the minimal hardened-runtime entitlements required for the app to launch under \`ENABLE_HARDENED_RUNTIME\`: \`allow-jit\`, \`allow-unsigned-executable-memory\`, \`disable-library-validation\` (for the GhosttyKit XCFramework), \`allow-dyld-environment-variables\`. Matches the standard iTerm2 / Warp set.
- Enable \`ENABLE_HARDENED_RUNTIME = YES\` on both the \`Bellith\` app target and the \`bellith-cli\` helper (every binary in a notarized bundle needs it).
- Add \`docs/security-posture.md\` documenting why each decision was made so a future auditor can re-evaluate rather than reverse-engineer.

Unblocks notarized distribution in #50 / #74.

Closes #72.

## Test plan
- [x] \`make generate && make build\` succeeds
- [x] \`PrivacyInfo.xcprivacy\` lands at \`Bellith.app/Contents/Resources/\`
- [x] \`codesign -d --entitlements -\` shows the full entitlement set signed in
- [x] \`xcodebuild -configuration Release -showBuildSettings | grep HARDENED\` reports \`YES\`
- [ ] End-to-end notarization dry-run once the release workflow from #50 / #74 is in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)