### PR TITLE
build: signed DMG + Homebrew cask release pipeline (closes #74)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,229 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.2.0). Must already exist."
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build, sign, notarize, release
+    runs-on: macos-14
+    env:
+      SCHEME: Bellith
+      CONFIG: Release
+      APP_NAME: Bellith
+      BUNDLE_ID: com.rec.bellith
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GH_REF#refs/tags/}"
+          fi
+          # Validate: "v" followed by semver-ish. Prevents shell metacharacters.
+          case "$TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) : ;;
+            *) echo "::error::invalid tag '$TAG' (expected v<major>.<minor>.<patch>)"; exit 1 ;;
+          esac
+          VERSION="${TAG#v}"
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.app
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Import Developer ID signing cert
+        env:
+          CERT_BASE64:       ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
+          CERT_PASSWORD:     ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/bellith-release.keychain-db"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+          printf '%s' "$CERT_BASE64" | base64 --decode -o "$CERT_PATH"
+          security import "$CERT_PATH" -P "$CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          # Prepend the release keychain to the user search list so xcodebuild can find the identity.
+          CURRENT_KEYCHAINS=$(security list-keychains -d user | sed 's/"//g')
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $CURRENT_KEYCHAINS
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Build (Release)
+        env:
+          BELLITH_MARKETING_VERSION: ${{ steps.tag.outputs.version }}
+          BELLITH_BUILD_NUMBER:      ${{ github.run_number }}
+          DEVELOPER_ID_APPLICATION:  ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_NAME }}
+          APPLE_TEAM_ID:             ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project Bellith.xcodeproj \
+            -scheme "$SCHEME" \
+            -configuration "$CONFIG" \
+            -destination 'generic/platform=macOS' \
+            -derivedDataPath build \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="$DEVELOPER_ID_APPLICATION" \
+            DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            OTHER_CODE_SIGN_FLAGS="--timestamp" \
+            build
+
+      - name: Locate built app
+        id: app
+        run: |
+          set -euo pipefail
+          APP_PATH="build/Build/Products/$CONFIG/$APP_NAME.app"
+          test -d "$APP_PATH" || { echo "::error::built app not found at $APP_PATH"; exit 1; }
+          echo "path=$APP_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Verify signature and runtime flags
+        env:
+          APP_PATH: ${{ steps.app.outputs.path }}
+        run: |
+          set -euo pipefail
+          codesign -dvvv "$APP_PATH"
+          codesign --verify --deep --strict --verbose=4 "$APP_PATH"
+          codesign -dvvv "$APP_PATH" 2>&1 | grep -q "flags=0x10000(runtime)" || {
+            echo "::error::Hardened Runtime flag missing from built app"; exit 1;
+          }
+
+      - name: Create DMG
+        id: dmg
+        env:
+          APP_PATH: ${{ steps.app.outputs.path }}
+          VERSION:  ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          brew install create-dmg
+          DMG_NAME="${APP_NAME}-${VERSION}.dmg"
+          DMG_PATH="$RUNNER_TEMP/$DMG_NAME"
+          STAGING="$RUNNER_TEMP/dmg-staging"
+          mkdir -p "$STAGING"
+          cp -R "$APP_PATH" "$STAGING/"
+          create-dmg \
+            --volname "$APP_NAME $VERSION" \
+            --window-size 540 360 \
+            --icon-size 96 \
+            --icon "$APP_NAME.app" 140 170 \
+            --app-drop-link 400 170 \
+            --hide-extension "$APP_NAME.app" \
+            --no-internet-enable \
+            "$DMG_PATH" "$STAGING" || {
+              # create-dmg occasionally exits non-zero even on success if hdiutil lingers.
+              [ -f "$DMG_PATH" ] || exit 1
+            }
+          echo "path=$DMG_PATH" >> "$GITHUB_OUTPUT"
+          echo "name=$DMG_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Sign DMG
+        env:
+          DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_NAME }}
+          DMG_PATH: ${{ steps.dmg.outputs.path }}
+        run: |
+          codesign --force --sign "$DEVELOPER_ID_APPLICATION" --timestamp --options runtime "$DMG_PATH"
+
+      - name: Notarize DMG
+        env:
+          APPLE_ID:           ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID:      ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          DMG_PATH:           ${{ steps.dmg.outputs.path }}
+        run: |
+          set -euo pipefail
+          xcrun notarytool submit "$DMG_PATH" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --wait
+          xcrun stapler staple "$DMG_PATH"
+          xcrun stapler validate "$DMG_PATH"
+
+      - name: Compute DMG sha256
+        id: shasum
+        env:
+          DMG_PATH: ${{ steps.dmg.outputs.path }}
+          DMG_NAME: ${{ steps.dmg.outputs.name }}
+        run: |
+          set -euo pipefail
+          SHA=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
+          SHA_PATH="$RUNNER_TEMP/$DMG_NAME.sha256"
+          echo "$SHA  $DMG_NAME" > "$SHA_PATH"
+          echo "sha256=$SHA"       >> "$GITHUB_OUTPUT"
+          echo "sha_path=$SHA_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Render updated Homebrew cask
+        id: cask
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+          SHA256:  ${{ steps.shasum.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          CASK_SRC="Casks/bellith.rb"
+          CASK_OUT="$RUNNER_TEMP/bellith.rb"
+          /usr/bin/sed -E \
+            -e "s/^([[:space:]]*version)[[:space:]]+\"[^\"]*\"/\\1 \"$VERSION\"/" \
+            -e "s/^([[:space:]]*sha256)[[:space:]]+.*$/\\1 \"$SHA256\"/" \
+            "$CASK_SRC" > "$CASK_OUT"
+          echo "path=$CASK_OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          draft: false
+          prerelease: ${{ contains(steps.tag.outputs.version, '-') }}
+          generate_release_notes: true
+          files: |
+            ${{ steps.dmg.outputs.path }}
+            ${{ steps.shasum.outputs.sha_path }}
+            ${{ steps.cask.outputs.path }}
+          body: |
+            Bellith ${{ steps.tag.outputs.version }}
+
+            **Install**
+            - `brew install --cask bellith`
+            - Or download `${{ steps.dmg.outputs.name }}` below.
+
+            **Integrity**
+            SHA-256: `${{ steps.shasum.outputs.sha256 }}`
+
+      - name: Clean keychain
+        if: always()
+        env:
+          KEYCHAIN_PATH: ${{ env.KEYCHAIN_PATH }}
+        run: |
+          [ -n "${KEYCHAIN_PATH:-}" ] && security delete-keychain "$KEYCHAIN_PATH" || true

--- a/Casks/bellith.rb
+++ b/Casks/bellith.rb
@@ -1,0 +1,27 @@
+cask "bellith" do
+  version "0.1.0"
+  sha256 :no_check # replaced per-release by the release workflow
+
+  url "https://github.com/RodrigoEspinosa/bellith/releases/download/v#{version}/Bellith-#{version}.dmg",
+      verified: "github.com/RodrigoEspinosa/bellith/"
+  name "Bellith"
+  desc "Native macOS terminal emulator built on Ghostty's rendering engine"
+  homepage "https://github.com/RodrigoEspinosa/bellith"
+
+  depends_on macos: ">= :sonoma"
+
+  app "Bellith.app"
+
+  # CLI helper embedded in the app bundle. Symlinking it here mirrors what
+  # most terminal casks do (iTerm2, Alacritty, Kitty) so `bellith` is on $PATH.
+  binary "#{appdir}/Bellith.app/Contents/Resources/bellith"
+
+  zap trash: [
+    "~/Library/Preferences/com.rec.bellith.plist",
+    "~/Library/Saved Application State/com.rec.bellith.savedState",
+    "~/Library/Caches/com.rec.bellith",
+    "~/Library/HTTPStorages/com.rec.bellith",
+  ]
+
+  uninstall quit: "com.rec.bellith"
+end

--- a/README.md
+++ b/README.md
@@ -22,7 +22,38 @@
 - **TERM-aware defaults** — Explicit `xterm-ghostty` advertising with an override for legacy tooling
 - **Frameless window** — Clean, minimal window chrome with custom title bar
 
+## Install
+
+The easiest way to try Bellith is the signed, notarized DMG attached to the [latest release](https://github.com/RodrigoEspinosa/bellith/releases/latest):
+
+```bash
+# Download + install the DMG
+open "https://github.com/RodrigoEspinosa/bellith/releases/latest"
+```
+
+Drag `Bellith.app` into `/Applications`. On first launch macOS will verify the notarization ticket — no "unidentified developer" prompt.
+
+### Homebrew cask
+
+Until Bellith is accepted into [homebrew-cask](https://github.com/Homebrew/homebrew-cask), install directly from the release artifact:
+
+```bash
+brew install --cask https://github.com/RodrigoEspinosa/bellith/releases/latest/download/bellith.rb
+```
+
+The release workflow publishes an up-to-date `bellith.rb` next to each DMG; Homebrew reads the SHA-256 from there and verifies the download before installing.
+
+### Verifying the download
+
+Every release ships a `.sha256` file alongside the DMG:
+
+```bash
+shasum -a 256 -c Bellith-<version>.dmg.sha256
+```
+
 ## Requirements
+
+For building from source:
 
 - macOS 14.0 (Sonoma) or later
 - Xcode 16.0+


### PR DESCRIPTION
## Summary

Stands up the \"go live\" path: tag push → signed, notarized DMG on GitHub Releases + an auto-generated Homebrew cask artifact.

- **\`.github/workflows/release.yml\`** — triggered by \`v*.*.*\` tag pushes (or \`workflow_dispatch\` with a validated tag). Builds Release with \`BELLITH_MARKETING_VERSION\` + CI run number (hooks into the versioning from #73), imports the Developer ID cert into an ephemeral keychain, signs with \`--timestamp\` + \`--options runtime\`, verifies the Hardened Runtime flag is present, packages into a DMG via \`create-dmg\`, signs + notarizes the DMG with \`notarytool --wait\`, staples the ticket, publishes a GitHub Release with the DMG, a \`.sha256\` file, and a rendered \`bellith.rb\` with the real \`version\` + \`sha256\`.
- **\`Casks/bellith.rb\`** — Homebrew cask source of truth. Version/sha fields are placeholders rewritten per-release by CI. Includes the \`bellith\` CLI symlink, \`zap\` paths, and \`quit\` uninstall.
- **README \"Install\" section** — DMG download, \`brew install --cask <release-url>/bellith.rb\` until Bellith is accepted into \`homebrew-cask\`, and a verify-the-shasum stanza. Build-from-source steps move under \"Requirements\" so the install path is the first thing a user sees.

### Secrets the workflow expects
Set these in **Repo Settings → Secrets and variables → Actions** before creating the first tag:

| Secret | Value |
|---|---|
| \`APPLE_DEVELOPER_ID_CERT\` | Base64 of the Developer ID \`.p12\` (\`base64 -i cert.p12 \| pbcopy\`) |
| \`APPLE_DEVELOPER_ID_CERT_PASSWORD\` | Password for that \`.p12\` |
| \`APPLE_DEVELOPER_ID_APPLICATION_NAME\` | \`Developer ID Application: Rodrigo Espinosa (TEAMID)\` (from \`security find-identity -v -p codesigning\`) |
| \`KEYCHAIN_PASSWORD\` | Any strong random string — only used to unlock the ephemeral CI keychain |
| \`APPLE_ID\` | Apple ID associated with the Developer Program |
| \`APPLE_TEAM_ID\` | 10-char team ID |
| \`APPLE_APP_SPECIFIC_PASSWORD\` | App-specific password from appleid.apple.com (not your iCloud password) |

### Security-sensitive bits
- \`inputs.tag\` from \`workflow_dispatch\` is validated against \`v<major>.<minor>.<patch>\` before being used in any shell context.
- Every user-controlled or secret value is passed through \`env:\` rather than interpolated directly into \`run:\` blocks.
- The release keychain is deleted in an \`always()\` step.

### Dependencies / merge order
- Needs **#72** (hardened runtime) merged first — otherwise the \`codesign -dvvv ... grep flags=0x10000(runtime)\` verification step fails.
- Uses **#73**'s \`scripts/stamp-version.sh\` via the \`BELLITH_MARKETING_VERSION\` / \`BELLITH_BUILD_NUMBER\` env vars.
- Homebrew cask points at \`Bellith-<version>.dmg\` asset names, which \`create-dmg\` produces.

### Out of scope / follow-up
- **#50 Sparkle auto-update** — deliberately split into its own PR so this one can ship v1 sooner. Users upgrade via \`brew upgrade --cask bellith\` or redownloading until Sparkle lands.
- A dedicated \`RodrigoEspinosa/homebrew-bellith\` tap or a homebrew-cask submission would make \`brew install --cask bellith\` work without a URL. The rendered \`bellith.rb\` asset on each release makes either migration one-step.

## Test plan
- [x] Workflow YAML parses (\`ruby -ryaml -e 'YAML.load_file(...)'\`)
- [x] Cask file is valid Ruby (\`ruby -c\`)
- [x] Secrets configured in repo settings
- [ ] Dry run via \`workflow_dispatch\` with a test tag (e.g. \`v0.2.0-rc1\`) — release marked as prerelease because version contains \`-\`
- [ ] Download the DMG from the release on a clean Mac; verify no Gatekeeper warning on first open
- [ ] \`brew install --cask https://github.com/RodrigoEspinosa/bellith/releases/download/v0.2.0-rc1/bellith.rb\` completes; \`bellith\` CLI appears on \`\$PATH\`

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)