### PR TITLE
fix(build): stabilize release workflow on GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,18 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
+      - name: Fetch GhosttyKit XCFramework
+        run: |
+          set -euo pipefail
+          GHOSTTYKIT_URL=$(ruby -e 'puts File.read("Package.swift")[/url:\s*"([^"]+)"/, 1]')
+          GHOSTTYKIT_SHA256=$(ruby -e 'puts File.read("Package.swift")[/checksum:\s*"([^"]+)"/, 1]')
+          ARCHIVE_PATH="$RUNNER_TEMP/GhosttyKit.xcframework.zip"
+          mkdir -p Frameworks
+          curl -L "$GHOSTTYKIT_URL" -o "$ARCHIVE_PATH"
+          echo "$GHOSTTYKIT_SHA256  $ARCHIVE_PATH" | shasum -a 256 -c -
+          rm -rf Frameworks/GhosttyKit.xcframework
+          ditto -x -k "$ARCHIVE_PATH" Frameworks
+
       - name: Generate Xcode project
         run: xcodegen generate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,16 @@ jobs:
         run: brew install xcodegen
 
       - name: Fetch GhosttyKit XCFramework
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          GHOSTTYKIT_URL=$(ruby -e 'puts File.read("Package.swift")[/url:\s*"([^"]+)"/, 1]')
+          GHOSTTYKIT_TAG=$(ruby -e 'puts File.read("Package.swift")[%r{releases/download/([^/]+)/}, 1]')
+          GHOSTTYKIT_ASSET_NAME=$(ruby -ruri -e 'url = File.read("Package.swift")[/url:\s*"([^"]+)"/, 1]; puts File.basename(URI(url).path)')
           GHOSTTYKIT_SHA256=$(ruby -e 'puts File.read("Package.swift")[/checksum:\s*"([^"]+)"/, 1]')
-          ARCHIVE_PATH="$RUNNER_TEMP/GhosttyKit.xcframework.zip"
+          ARCHIVE_PATH="$RUNNER_TEMP/$GHOSTTYKIT_ASSET_NAME"
           mkdir -p Frameworks
-          curl -L "$GHOSTTYKIT_URL" -o "$ARCHIVE_PATH"
+          gh release download "$GHOSTTYKIT_TAG" -p "$GHOSTTYKIT_ASSET_NAME" -D "$RUNNER_TEMP" --clobber
           echo "$GHOSTTYKIT_SHA256  $ARCHIVE_PATH" | shasum -a 256 -c -
           rm -rf Frameworks/GhosttyKit.xcframework
           ditto -x -k "$ARCHIVE_PATH" Frameworks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,9 @@ jobs:
           fetch-depth: 0
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.app
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - name: Install XcodeGen
         run: brew install xcodegen


### PR DESCRIPTION
## Summary
- replace the hardcoded Xcode app path with `setup-xcode` so the workflow uses an installed runner Xcode
- fetch `GhosttyKit.xcframework` from the tagged GitHub Release asset before generating the project and building
- verify the downloaded archive against the checksum from `Package.swift`

## Testing
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/release.yml"); puts "workflow ok"'`
- triggered `Release` against `v0.1.1-rc1` from this branch
- confirmed the workflow now gets through Xcode selection, project generation, certificate import, release build, app signature verification, DMG creation, and DMG signing
- latest run: https://github.com/RodrigoEspinosa/bellith/actions/runs/24914878725
- current remaining blocker is Apple notarization returning `Invalid` for submission `dc1f7633-fdb6-4d13-800a-8949f1306d34`
