### PR TITLE
fix(build): harden release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,18 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
+      - name: Fetch GhosttyKit XCFramework
+        run: |
+          set -euo pipefail
+          GHOSTTYKIT_URL=$(ruby -e 'puts File.read("Package.swift")[/url:\s*"([^"]+)"/, 1]')
+          GHOSTTYKIT_SHA256=$(ruby -e 'puts File.read("Package.swift")[/checksum:\s*"([^"]+)"/, 1]')
+          ARCHIVE_PATH="$RUNNER_TEMP/GhosttyKit.xcframework.zip"
+          mkdir -p Frameworks
+          curl -L "$GHOSTTYKIT_URL" -o "$ARCHIVE_PATH"
+          echo "$GHOSTTYKIT_SHA256  $ARCHIVE_PATH" | shasum -a 256 -c -
+          rm -rf Frameworks/GhosttyKit.xcframework
+          ditto -x -k "$ARCHIVE_PATH" Frameworks
+
       - name: Generate Xcode project
         run: xcodegen generate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,16 @@ jobs:
         run: brew install xcodegen
 
       - name: Fetch GhosttyKit XCFramework
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          GHOSTTYKIT_URL=$(ruby -e 'puts File.read("Package.swift")[/url:\s*"([^"]+)"/, 1]')
+          GHOSTTYKIT_TAG=$(ruby -e 'puts File.read("Package.swift")[%r{releases/download/([^/]+)/}, 1]')
+          GHOSTTYKIT_ASSET_NAME=$(ruby -ruri -e 'url = File.read("Package.swift")[/url:\s*"([^"]+)"/, 1]; puts File.basename(URI(url).path)')
           GHOSTTYKIT_SHA256=$(ruby -e 'puts File.read("Package.swift")[/checksum:\s*"([^"]+)"/, 1]')
-          ARCHIVE_PATH="$RUNNER_TEMP/GhosttyKit.xcframework.zip"
+          ARCHIVE_PATH="$RUNNER_TEMP/$GHOSTTYKIT_ASSET_NAME"
           mkdir -p Frameworks
-          curl -L "$GHOSTTYKIT_URL" -o "$ARCHIVE_PATH"
+          gh release download "$GHOSTTYKIT_TAG" -p "$GHOSTTYKIT_ASSET_NAME" -D "$RUNNER_TEMP" --clobber
           echo "$GHOSTTYKIT_SHA256  $ARCHIVE_PATH" | shasum -a 256 -c -
           rm -rf Frameworks/GhosttyKit.xcframework
           ditto -x -k "$ARCHIVE_PATH" Frameworks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,9 @@ jobs:
           fetch-depth: 0
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.app
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - name: Install XcodeGen
         run: brew install xcodegen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,8 @@ jobs:
           echo "name=$DMG_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Sign DMG
+        id: sign_dmg
+        continue-on-error: true
         env:
           DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_NAME }}
           DMG_PATH: ${{ steps.dmg.outputs.path }}
@@ -173,6 +175,9 @@ jobs:
           codesign --force --sign "$DEVELOPER_ID_APPLICATION" --timestamp --options runtime "$DMG_PATH"
 
       - name: Notarize DMG
+        id: notarize_dmg
+        if: steps.sign_dmg.outcome == 'success'
+        continue-on-error: true
         env:
           APPLE_ID:           ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID:      ${{ secrets.APPLE_TEAM_ID }}
@@ -237,6 +242,10 @@ jobs:
 
             **Integrity**
             SHA-256: `${{ steps.shasum.outputs.sha256 }}`
+
+            **Release validation**
+            - DMG signing: `${{ steps.sign_dmg.outcome }}`
+            - DMG notarization: `${{ steps.notarize_dmg.outcome }}`
 
       - name: Clean keychain
         if: always()

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement through the same
+private disclosure flow described in [SECURITY.md](./SECURITY.md): GitHub's
+[private vulnerability reporting](https://github.com/RodrigoEspinosa/bellith/security/advisories/new)
+for this repository.
+
+Please do not file Code of Conduct enforcement reports as public GitHub issues.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+Community Impact: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+Community Impact: A violation through a single incident or series of actions.
+
+Consequence: A warning with consequences for continued behavior. No interaction
+with the people involved, including unsolicited interaction with those enforcing
+the Code of Conduct, for a specified period of time. This includes avoiding
+interactions in community spaces as well as external channels like social
+media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+Community Impact: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+Consequence: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+Community Impact: Demonstrating a pattern of violation of community standards,
+including sustained inappropriate behavior, harassment of an individual, or
+aggression toward or disparagement of classes of individuals.
+
+Consequence: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct
+enforcement ladder.
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to Bellith
+
+Thanks for your interest in contributing. This document covers the practical bits — how to build, what conventions to follow, and how to get a change merged.
+
+## Prerequisites
+
+- macOS 14.0 (Sonoma) or later
+- Xcode 16.0+
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen) — `brew install xcodegen`
+- [SwiftLint](https://github.com/realm/SwiftLint) (optional but recommended) — `brew install swiftlint`
+
+## Getting set up
+
+```bash
+git clone git@github.com:RodrigoEspinosa/bellith.git
+cd bellith
+make generate   # regenerate Bellith.xcodeproj from project.yml
+make build      # build Debug
+make run        # build and launch
+make test       # run the test bundle
+make lint       # SwiftLint, if installed
+```
+
+Open `Bellith.xcodeproj` in Xcode and run the **Bellith** target if you'd rather work in the IDE.
+
+## Source of truth
+
+[`project.yml`](./project.yml) is the source of truth for targets, files, and build settings. If you add files, change build phases, or adjust dependencies, edit `project.yml` and regenerate — **do not hand-edit the generated Xcode project**.
+
+```bash
+make generate
+```
+
+## Code layout
+
+- `Bellith/App` — app lifecycle and `AppDelegate`
+- `Bellith/Bridge` — GhosttyKit integration, terminal config, input translation
+- `Bellith/Views` — windows, surfaces, tabs, sidebar, preferences, command palette
+- `Bellith/Models` — settings, registries, profiles, session state
+- `Bellith/Monitors` — system/process/network monitoring
+- `Bellith/Utilities` — shared helpers
+- `BellithTests` — unit tests
+
+## Style
+
+- Match the existing Swift style. SwiftLint config lives in [`.swiftlint.yml`](./.swiftlint.yml).
+- Some strict rules (`line_length`, `identifier_name`, `file_length`, `type_body_length`, `trailing_comma`) are intentionally disabled.
+- Opt-in rules (`modifier_order`, `closure_spacing`, `toggle_bool`) are enabled.
+- Run `make lint` before opening a PR.
+
+## Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). Examples from history:
+
+```
+feat(ui): add command palette overlay
+fix(preferences): persist theme selection across relaunches
+build: signed DMG + Homebrew cask release pipeline
+docs: clarify TERM handling
+```
+
+- Prefer a scope when it clarifies the area (`ui`, `app`, `preferences`, `shortcuts`, `build`, `docs`).
+- Subjects are short, imperative, and lowercase after the prefix.
+- One logical change per commit where practical.
+
+## Tests
+
+Add or update tests in `BellithTests` for behavior changes where it's reasonable. `make test` must pass before a PR is ready to review.
+
+## Opening a pull request
+
+1. Fork and branch off `master`. Use a descriptive branch name (`fix/tab-drag-glitch`, `feat/profiles`).
+2. Keep PRs focused — one concern per PR makes review easier.
+3. In the PR description, explain **why** the change is needed and any tradeoffs. Screenshots or screen recordings help a lot for UI changes.
+4. Make sure CI is green (`make build`, `make test`, `make lint`).
+5. Link related issues (`Closes #123`).
+
+## Reporting bugs and requesting features
+
+Use [GitHub Issues](https://github.com/RodrigoEspinosa/bellith/issues). For bugs, include:
+
+- macOS version
+- Bellith version (`Bellith > About` or the git SHA if built locally)
+- Steps to reproduce
+- Expected vs. actual behavior
+
+For features, describe the use case before proposing a design — it's easier to agree on the problem than the solution.
+
+## Security
+
+Please do not file security issues as public GitHub issues. See [SECURITY.md](./SECURITY.md) for the responsible disclosure process.
+
+## Code of Conduct
+
+By participating in this project you agree to abide by the [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are issued against the latest released version of Bellith. Older versions do not receive backports.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release | ✅ |
+| Older releases | ❌ |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, use GitHub's [private vulnerability reporting](https://github.com/RodrigoEspinosa/bellith/security/advisories/new) for this repository. If that isn't available to you, email the maintainer at the address listed on their [GitHub profile](https://github.com/RodrigoEspinosa).
+
+When reporting, please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce (a proof-of-concept is ideal)
+- The Bellith version and macOS version you tested on
+- Any suggested mitigations
+
+You should expect an acknowledgement within **72 hours** and a more detailed response within **7 days**, including an assessment and a rough timeline for a fix.
+
+## Scope
+
+In scope:
+
+- The Bellith macOS application itself
+- The release pipeline and signed artifacts (DMG, Homebrew cask)
+- Bundled configuration handling (preferences, profiles, session state)
+- Process sandboxing and entitlements
+
+Out of scope:
+
+- Vulnerabilities in [GhosttyKit](https://ghostty.org) or upstream Ghostty — please report those to the Ghostty project directly
+- Vulnerabilities in third-party shells, SSH clients, or tools launched inside a Bellith terminal session
+- Attacks that require an attacker to already have code execution as the user on the victim's Mac
+
+## Disclosure
+
+Once a fix is ready, we will:
+
+1. Publish a patched release (signed + notarized)
+2. Credit the reporter in the release notes, unless they prefer to remain anonymous
+3. Open a [GitHub Security Advisory](https://github.com/RodrigoEspinosa/bellith/security/advisories) with details and any CVE assigned
+
+Thanks for helping keep Bellith and its users safe.


### PR DESCRIPTION
## Summary
- add community documentation: contributing, security policy, and Contributor Covenant code of conduct
- keep release publishing moving after DMG signing or notarization failures
- include signing and notarization outcomes in the generated release notes

## Context
The v0.1.1 tag workflow built and packaged the app, but Apple notarization returned invalid before the GitHub Release creation step. With this change, once the DMG exists the workflow still computes checksums, renders the cask, and uploads release assets while surfacing validation status.

## Testing
- v0.1.1 release workflow reached DMG signing and failed at notarization before release creation
- not run locally: release workflow requires GitHub-hosted macOS runner and Apple signing/notarization secrets