### PR TITLE
fix(build): remove debug entitlements from release cli

### DIFF
--- a/Bellith.xcodeproj/project.pbxproj
+++ b/Bellith.xcodeproj/project.pbxproj
@@ -829,6 +829,7 @@
 		7047BB4BB99F5395C1845743 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_HARDENED_RUNTIME = YES;

--- a/project.yml
+++ b/project.yml
@@ -86,6 +86,9 @@ targets:
         SKIP_INSTALL: YES
         CODE_SIGN_STYLE: Automatic
         ENABLE_HARDENED_RUNTIME: YES
+      configs:
+        Release:
+          CODE_SIGN_INJECT_BASE_ENTITLEMENTS: NO
 
   BellithTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary
- disable Xcode base entitlement injection for the bellith-cli Release configuration
- regenerate Bellith.xcodeproj from project.yml

## Why
Apple notarization rejected Bellith-0.1.1.dmg because Bellith.app/Contents/Resources/bellith requested com.apple.security.get-task-allow for both x86_64 and arm64. That entitlement is only valid for development/debug signing and must not be present in distribution artifacts.

## Verification
- xcodegen generate
- xcodebuild -project Bellith.xcodeproj -target bellith-cli -configuration Release -showBuildSettings | rg 'CODE_SIGN_INJECT_BASE_ENTITLEMENTS|ENABLE_HARDENED_RUNTIME|PRODUCT_NAME|CODE_SIGN_STYLE'
- verified Release bellith-cli reports CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO and ENABLE_HARDENED_RUNTIME = YES