### PR TITLE
fix(build): verify app signature inside release dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,6 @@ jobs:
             --icon-size 96 \
             --icon "$APP_NAME.app" 140 170 \
             --app-drop-link 400 170 \
-            --hide-extension "$APP_NAME.app" \
             --no-internet-enable \
             "$DMG_PATH" "$STAGING" || {
               # create-dmg occasionally exits non-zero even on success if hdiutil lingers.
@@ -164,6 +163,17 @@ jobs:
             }
           echo "path=$DMG_PATH" >> "$GITHUB_OUTPUT"
           echo "name=$DMG_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Verify app signature inside DMG
+        env:
+          DMG_PATH: ${{ steps.dmg.outputs.path }}
+        run: |
+          set -euo pipefail
+          MOUNT_DIR="$RUNNER_TEMP/dmg-verify"
+          mkdir -p "$MOUNT_DIR"
+          hdiutil attach "$DMG_PATH" -readonly -nobrowse -mountpoint "$MOUNT_DIR"
+          trap 'hdiutil detach "$MOUNT_DIR" || true' EXIT
+          codesign --verify --deep --strict --verbose=4 "$MOUNT_DIR/$APP_NAME.app"
 
       - name: Sign DMG
         id: sign_dmg


### PR DESCRIPTION
## Summary
- remove create-dmg's --hide-extension option, which can mutate the signed app bundle metadata during packaging
- mount the completed DMG and verify Bellith.app's code signature before DMG signing and notarization

## Why
v0.1.2 published successfully, but notarization still returned Invalid. Inspecting the published DMG locally showed Bellith.app failed codesign verification from inside the mounted DMG with: invalid signature (code or signature have been modified). The workflow previously verified the app before packaging, but not after create-dmg.

## Verification
- downloaded v0.1.2 DMG with gh release download
- mounted it read-only with hdiutil
- confirmed codesign --verify --deep --strict fails for Bellith.app from the mounted DMG
- this workflow adds that exact post-packaging verification before notarization